### PR TITLE
서버와 클라이언트 통합 실행 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ logs
 
 # Build output
 client/dist
+client/build
 server/dist
 
 # Mac

--- a/client/app/root.tsx
+++ b/client/app/root.tsx
@@ -2,7 +2,10 @@ import { Link, Outlet } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./globals.css";
-import "./pwa";
+
+if (typeof window !== "undefined") {
+  import("./pwa");
+}
 
 const queryClient = new QueryClient();
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import type { Server } from "http";
 import cors from "cors";
+import path from "path";
 import { createProfile, getProfiles } from "./profileStore";
 
 const app = express();
@@ -35,6 +36,14 @@ export function startServer(userDataPath: string): Promise<Server> {
     });
     res.status(201).json(profile);
   });
+
+  if (process.env.NODE_ENV === "production") {
+    const clientPath = path.join(__dirname, "../../client/build/client");
+    app.use(express.static(clientPath));
+    app.get("*", (_req, res) => {
+      res.sendFile(path.join(clientPath, "index.html"));
+    });
+  }
 
   return new Promise((resolve, reject) => {
     if (server) {

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,5 +1,5 @@
-import { app, BrowserWindow } from 'electron';
-import { startServer, stopServer } from './index';
+import { app, BrowserWindow } from "electron";
+import { startServer, stopServer } from "./index";
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -9,13 +9,15 @@ function createWindow() {
       contextIsolation: true,
     },
   });
-
-  win.loadURL('http://localhost:5173/admin');
+  const url = app.isPackaged
+    ? "http://localhost:3000/admin"
+    : "http://localhost:5173/admin";
+  win.loadURL(url);
 }
 
-app.whenReady().then(() => {
-  const dataPath = app.getPath('userData');
-  startServer(dataPath);
+app.whenReady().then(async () => {
+  const dataPath = app.getPath("userData");
+  await startServer(dataPath);
   createWindow();
 
   app.on('activate', () => {


### PR DESCRIPTION
## 요약
- Electron 앱이 패키징된 상태에서 Express 서버와 React Router 앱을 함께 실행하도록 변경했습니다.
- `client/build` 결과물을 Express가 서빙하도록 하고, 패키징 여부에 따라 로드 URL을 선택합니다.
- PWA 스크립트가 서버 사이드에서 실행되지 않도록 동적 import 적용
- `client/build` 폴더를 gitignore에 추가했습니다.

## 테스트
- `npm run lint`
- `npm test -w server`


------
https://chatgpt.com/codex/tasks/task_e_68728cd64bfc8330b8c2f461a5303443