### PR TITLE
홈 화면 스타일 개선

### DIFF
--- a/client/app/components/ui/card.tsx
+++ b/client/app/components/ui/card.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+};

--- a/client/app/components/ui/input.tsx
+++ b/client/app/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/client/app/components/ui/label.tsx
+++ b/client/app/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "~/lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<"label">,
+  React.ComponentPropsWithoutRef<"label">
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/client/app/routes/_index.tsx
+++ b/client/app/routes/_index.tsx
@@ -1,6 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
 import { useProfileStore, type Profile } from "../store";
 import { fetchProfiles, postProfile } from "../lib/api";
 
@@ -23,42 +26,59 @@ export default function Home() {
   const [role, setRole] = useState("세션 사용자");
 
   return (
-    <div className="space-y-4">
-      <h1>프로필 선택</h1>
-      <ul className="space-y-2">
-        {profiles?.map((p: Profile) => (
-          <li key={p.id}>
-            <Button onClick={() => setProfile(p)}>{p.name} ({p.role})</Button>
-          </li>
-        ))}
-      </ul>
-
-      <h2 className="mt-4">새 프로필 생성</h2>
-      <div className="flex gap-2">
-        <input
-          className="border p-2"
-          placeholder="이름"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <select
-          className="border p-2"
-          value={role}
-          onChange={(e) => setRole(e.target.value)}
-        >
-          <option value="세션 사용자">세션 사용자</option>
-          <option value="인도자">인도자</option>
-          <option value="목사님">목사님</option>
-        </select>
-        <Button
-          onClick={() => {
-            mutation.mutate({ name, role });
-            setName("");
-          }}
-        >
-          생성
-        </Button>
-      </div>
-    </div>
+    <Card className="mx-auto max-w-md">
+      <CardHeader>
+        <CardTitle>프로필 선택</CardTitle>
+        <CardDescription>프로필을 선택하거나 새로 만드세요.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ul className="space-y-2">
+          {profiles?.map((p: Profile) => (
+            <li key={p.id}>
+              <Button
+                className="w-full justify-start"
+                variant="secondary"
+                onClick={() => setProfile(p)}
+              >
+                {p.name} ({p.role})
+              </Button>
+            </li>
+          ))}
+        </ul>
+        <div className="space-y-2">
+          <div className="space-y-1">
+            <Label htmlFor="name">이름</Label>
+            <Input
+              id="name"
+              placeholder="이름"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="role">역할</Label>
+            <select
+              id="role"
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+            >
+              <option value="세션 사용자">세션 사용자</option>
+              <option value="인도자">인도자</option>
+              <option value="목사님">목사님</option>
+            </select>
+          </div>
+          <Button
+            className="w-full"
+            onClick={() => {
+              mutation.mutate({ name, role });
+              setName("");
+            }}
+          >
+            생성
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## 변경 내용
- shadcn/ui 컴포넌트를 활용해 홈 화면을 카드 형태로 개선
- 입력 필드와 라벨, 카드 컴포넌트 추가

## 테스트 결과
- `npm run lint` 실행 결과 문제 없음
- `npm test -w server` 실행 시 "No tests" 출력


------
https://chatgpt.com/codex/tasks/task_e_6873204db7a083308f689fa13d9775be