### PR TITLE
feat: 빠른 연속 스와이프 끊김 제거 + 모바일 반응형 + 목록/편집 UI 정리

### DIFF
--- a/client/src/components/worship/CommandPanel.tsx
+++ b/client/src/components/worship/CommandPanel.tsx
@@ -6,6 +6,7 @@ import { panelTransition, panelContentTransition } from "./panelMotion";
 
 interface CommandPanelProps {
   show: boolean;
+  isMobile: boolean;
   width: string;
   reducedMotion: boolean;
   commands: Command[];
@@ -13,22 +14,35 @@ interface CommandPanelProps {
 }
 
 // 우측 명령 전송 패널 (슬라이드 인/아웃).
-function CommandPanel({ show, width, reducedMotion, commands, onSendCommand }: CommandPanelProps) {
+// 폰(isMobile)에선 밀어내기 대신 우측 오버레이 드로어로 동작한다.
+function CommandPanel({ show, isMobile, width, reducedMotion, commands, onSendCommand }: CommandPanelProps) {
+  const drawerWidth = isMobile ? "18rem" : width;
   return (
     <motion.aside
       aria-hidden={!show}
       inert={!show}
       initial={false}
-      animate={show ? { width, opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: 12 }}
+      animate={
+        isMobile
+          ? { x: show ? 0 : "100%", width: "18rem", opacity: 1 }
+          : show
+            ? { width, opacity: 1, x: 0 }
+            : { width: "0rem", opacity: 0, x: 12 }
+      }
       transition={reducedMotion ? { duration: 0 } : panelTransition}
-      className={cn("shrink-0 bg-viewer-panel overflow-hidden", show && "border-l border-viewer-border")}
+      className={cn(
+        "bg-viewer-panel overflow-hidden",
+        isMobile
+          ? "absolute inset-y-0 right-0 z-40 w-72 border-l border-viewer-border shadow-2xl"
+          : cn("shrink-0", show && "border-l border-viewer-border"),
+      )}
       style={{ pointerEvents: show ? "auto" : "none" }}
     >
       <motion.div
         animate={show ? { opacity: 1, x: 0 } : { opacity: 0, x: 8 }}
         transition={reducedMotion ? { duration: 0 } : panelContentTransition}
         className="h-full overflow-y-auto p-4 box-border"
-        style={{ width }}
+        style={{ width: drawerWidth }}
       >
         <h2 className="text-lg font-bold text-viewer-foreground mb-4">명령 전송</h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">

--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -76,7 +76,7 @@ function DrawingToolbar({
     >
       <div className="overflow-hidden">
         <div
-          className="bg-viewer-panel border-b border-viewer-border px-6 py-3 flex items-center justify-between"
+          className="bg-viewer-panel border-b border-viewer-border px-3 sm:px-6 py-3 flex items-center justify-between gap-2 overflow-x-auto"
           style={{
             opacity: isCompact ? 0 : 1,
             transform: isCompact ? "translateY(-100%)" : "translateY(0)",

--- a/client/src/components/worship/SheetListSidebar.tsx
+++ b/client/src/components/worship/SheetListSidebar.tsx
@@ -9,6 +9,7 @@ import { panelTransition, panelContentTransition } from "./panelMotion";
 
 interface SheetListSidebarProps {
   show: boolean;
+  isMobile: boolean;
   reducedMotion: boolean;
   sheets: Sheet[];
   currentSheetId: string | null;
@@ -18,8 +19,10 @@ interface SheetListSidebarProps {
 }
 
 // 좌측 악보 리스트 (슬라이드 인/아웃 + 접속자 표시).
+// 폰(isMobile)에선 밀어내기 대신 좌측 오버레이 드로어로 동작한다.
 function SheetListSidebar({
   show,
+  isMobile,
   reducedMotion,
   sheets,
   currentSheetId,
@@ -32,9 +35,20 @@ function SheetListSidebar({
       aria-hidden={!show}
       inert={!show}
       initial={false}
-      animate={show ? { width: "16rem", opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: -12 }}
+      animate={
+        isMobile
+          ? { x: show ? 0 : "-100%", width: "16rem", opacity: 1 }
+          : show
+            ? { width: "16rem", opacity: 1, x: 0 }
+            : { width: "0rem", opacity: 0, x: -12 }
+      }
       transition={reducedMotion ? { duration: 0 } : panelTransition}
-      className={cn("shrink-0 bg-viewer-panel overflow-hidden", show && "border-r border-viewer-border")}
+      className={cn(
+        "bg-viewer-panel overflow-hidden",
+        isMobile
+          ? "absolute inset-y-0 left-0 z-40 w-64 border-r border-viewer-border shadow-2xl"
+          : cn("shrink-0", show && "border-r border-viewer-border"),
+      )}
       style={{ pointerEvents: show ? "auto" : "none" }}
     >
       {/* 좌측은 첫 flex 항목이라 콘텐츠가 화면 끝에 고정됨 → 내부 독립 translate를

--- a/client/src/components/worship/WorshipHeader.tsx
+++ b/client/src/components/worship/WorshipHeader.tsx
@@ -37,7 +37,7 @@ function WorshipHeader({
     >
       <div className="overflow-hidden">
         <header
-          className="bg-viewer-panel border-b border-viewer-border px-6 py-4 flex items-center justify-between"
+          className="bg-viewer-panel border-b border-viewer-border px-3 sm:px-6 py-4 flex items-center justify-between gap-2"
           style={{
             opacity: isCompact ? 0 : 1,
             transform: isCompact ? "translateY(-100%)" : "translateY(0)",
@@ -45,8 +45,8 @@ function WorshipHeader({
           }}
           inert={isCompact}
         >
-          <div className="flex items-center gap-4">
-            <Button variant="ghost" size="icon" className="hover:bg-white/10 text-viewer-muted" asChild>
+          <div className="flex items-center gap-2 sm:gap-4 min-w-0">
+            <Button variant="ghost" size="icon" className="hover:bg-white/10 text-viewer-muted shrink-0" asChild>
               <Link to="/worship-list">
                 <ArrowLeft className="w-6 h-6" />
               </Link>
@@ -54,19 +54,19 @@ function WorshipHeader({
             <Button
               variant="ghost"
               size="icon"
-              className="hover:bg-white/10 text-viewer-muted"
+              className="hover:bg-white/10 text-viewer-muted shrink-0"
               onClick={onToggleSidebar}
             >
               <Menu className="w-6 h-6" />
             </Button>
-            <div className="h-8 w-px bg-viewer-border" />
-            <h1 className="text-xl font-bold text-viewer-foreground">{worshipTitle || "예배"}</h1>
+            <div className="h-8 w-px bg-viewer-border shrink-0" />
+            <h1 className="text-base sm:text-xl font-bold text-viewer-foreground truncate">{worshipTitle || "예배"}</h1>
           </div>
 
-          <div className="flex items-center gap-3">
-            {/* 서버 연결 상태 인디케이터 */}
+          <div className="flex items-center gap-2 sm:gap-3 shrink-0">
+            {/* 서버 연결 상태 인디케이터 (좁은 폭에선 숨김 → 플로팅 인디케이터로 대체) */}
             {!isConnected && (
-              <div className="flex items-center gap-2 px-3 py-1.5 bg-red-600/20 border border-red-500/30 rounded-lg">
+              <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 bg-red-600/20 border border-red-500/30 rounded-lg">
                 <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
                 <span className="text-xs font-medium text-red-400">연결 끊김</span>
               </div>
@@ -74,7 +74,7 @@ function WorshipHeader({
             <Button variant="ghost" size="sm" className="bg-white/5 text-viewer-muted hover:bg-white/10" asChild>
               <Link to={`/worship-edit/${worshipId}`}>
                 <Edit className="w-5 h-5" />
-                <span>편집</span>
+                <span className="hidden sm:inline">편집</span>
               </Link>
             </Button>
             {/* 컴팩트 시 헤더가 접히면 포털된 PopoverContent도 함께 닫음(inert는 포털 밖을 못 막음) */}

--- a/client/src/hooks/useSheetPageMotion.ts
+++ b/client/src/hooks/useSheetPageMotion.ts
@@ -156,13 +156,15 @@ export function useSheetPageMotion({
     const w = widthRef.current;
     stopAnimation();
     const newX = x.get() + dir * w;
-    baseOffsetRef.current = newX;
     committedPageRef.current = target;
     inFlightRef.current = null;
     resetPreview();
     setIsAnimating(false);
-    x.set(newX);
+    // 부모 commitPage가 cancelPageMotion으로 x/baseOffset을 0으로 되돌리므로,
+    // 재앵커(baseOffset/x = newX)는 반드시 onCommitPage "후"에 적용해야 점프가 안 생긴다.
     onCommitPage(target);
+    baseOffsetRef.current = newX;
+    x.set(newX);
   }, [stopAnimation, x, resetPreview, onCommitPage]);
 
   // 버튼/프로그램 내비용: 진행 중 커밋을 즉시 홈으로 마무리(작은 스냅 허용).
@@ -304,13 +306,13 @@ export function useSheetPageMotion({
         if (Math.abs(mx) > CLICK_DRAG_THRESHOLD) {
           markSuppressNextClick();
         }
-        if (intendedTarget !== activeTargetPage) {
-          setActiveTargetPage(intendedTarget);
-        }
-        if (intendedDir !== activeDirection) {
-          directionRef.current = intendedDir;
-          setActiveDirection(intendedDir);
-        }
+        // 인터럽트 직후엔 activeTargetPage/activeDirection(closure 값)이 stale이라
+        // `!==` 게이트로 비교하면 같은 방향 연속 플릭에서 방향/타깃이 복구되지 않는다.
+        // directionRef는 매 프레임 동기화(previewX 즉시 보정), state는 무조건 set
+        // (값이 같으면 React가 리렌더를 bail-out 하므로 비용 없음).
+        directionRef.current = intendedDir;
+        setActiveTargetPage(intendedTarget);
+        setActiveDirection(intendedDir);
         // baseOffset은 인터럽트로 이어받은 드래그의 시작 좌표(일반 드래그는 0).
         x.set(baseOffsetRef.current + offset);
       }

--- a/client/src/hooks/useSheetPageMotion.ts
+++ b/client/src/hooks/useSheetPageMotion.ts
@@ -47,6 +47,16 @@ export function useSheetPageMotion({
   const directionRef = useRef<-1 | 1 | null>(null);
   const widthRef = useRef(0);
 
+  // 진행 중인 전환을 끊김 없이 이어받기 위한 상태(빠른 연속 스와이프 지원)
+  // - committedPageRef: 훅이 동기적으로 아는 "현재 홈 페이지". 부모 currentPage는
+  //   onCommitPage가 비동기라 한 프레임 늦으므로, 인터럽트한 제스처가 직전 목표를
+  //   기준으로 다음 페이지를 계산할 수 있도록 훅이 직접 들고 있는다.
+  // - inFlightRef: 진행 중인 커밋 애니메이션이 향하던 목표(인터럽트 시 무엇을 확정할지).
+  // - baseOffsetRef: 인터럽트 후 이어받은 드래그의 시작 앵커. active에서 x = base + mx.
+  const committedPageRef = useRef(currentPage);
+  const inFlightRef = useRef<{ target: number; dir: -1 | 1 } | null>(null);
+  const baseOffsetRef = useRef(0);
+
   directionRef.current = activeDirection;
   widthRef.current = containerWidth;
 
@@ -56,6 +66,15 @@ export function useSheetPageMotion({
     if (dir === null || w === 0) return 0;
     return value + dir * w;
   });
+
+  // 부모 currentPage 변화를 따라가되, 훅이 직접 리드 중(드래그/커밋 진행)일 땐
+  // committedPageRef를 덮어쓰지 않는다 — 연속 스와이프 체이닝 중 off-by-one 방지.
+  // (사이드바 클릭 등 외부 페이지 변경은 idle 상태에서 동기화된다.)
+  useEffect(() => {
+    if (!isDragging && inFlightRef.current === null) {
+      committedPageRef.current = currentPage;
+    }
+  }, [currentPage, isDragging]);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -125,44 +144,95 @@ export function useSheetPageMotion({
     [x, stopAnimation, reducedMotion],
   );
 
+  // 드래그 인터럽트용: 진행 중이던 커밋을 즉시 "확정"하되, 들어오던 미리보기 카드를
+  // 같은 화면 위치에 그대로 둬서 점프 없이 새 드래그로 이어받는다.
+  // 미리보기(target)는 previewX = x + dir*w 위치에 있으므로 그 좌표를 새 메인 카드의
+  // 시작 앵커(baseOffset)로 삼고 x도 그 자리에 둔다. onCommitPage로 부모가 target을
+  // 메인으로 렌더 → x.set과 같은 프레임에 반영되어 깜빡임 없음(기존 완료 콜백과 동일 패턴).
+  const finalizeInFlightForDrag = useCallback(() => {
+    const inFlight = inFlightRef.current;
+    if (!inFlight) return;
+    const { target, dir } = inFlight;
+    const w = widthRef.current;
+    stopAnimation();
+    const newX = x.get() + dir * w;
+    baseOffsetRef.current = newX;
+    committedPageRef.current = target;
+    inFlightRef.current = null;
+    resetPreview();
+    setIsAnimating(false);
+    x.set(newX);
+    onCommitPage(target);
+  }, [stopAnimation, x, resetPreview, onCommitPage]);
+
+  // 버튼/프로그램 내비용: 진행 중 커밋을 즉시 홈으로 마무리(작은 스냅 허용).
+  const hardFinalizeInFlight = useCallback(() => {
+    const inFlight = inFlightRef.current;
+    if (!inFlight) return;
+    const { target } = inFlight;
+    stopAnimation();
+    baseOffsetRef.current = 0;
+    committedPageRef.current = target;
+    inFlightRef.current = null;
+    resetPreview();
+    setIsAnimating(false);
+    x.set(0);
+    onCommitPage(target);
+  }, [stopAnimation, x, resetPreview, onCommitPage]);
+
   const cancelPageMotion = useCallback(() => {
     stopAnimation();
     setIsAnimating(false);
     setIsDragging(false);
     resetPreview();
+    inFlightRef.current = null;
+    baseOffsetRef.current = 0;
     x.set(0);
   }, [stopAnimation, x, resetPreview]);
 
   const goToPageWithMotion = useCallback(
     (nextPage: number) => {
       if (nextPage < 0 || nextPage >= pageCount) return;
-      if (nextPage === currentPage) return;
-      if (isAnimating) return;
+      // 진행 중 전환이 있으면 즉시 마무리한 뒤 새 내비게이션을 시작한다.
+      if (inFlightRef.current) hardFinalizeInFlight();
 
-      if (Math.abs(nextPage - currentPage) !== 1) {
+      const fromPage = committedPageRef.current;
+      if (nextPage === fromPage) return;
+
+      if (Math.abs(nextPage - fromPage) !== 1) {
+        baseOffsetRef.current = 0;
+        committedPageRef.current = nextPage;
+        x.set(0);
         onCommitPage(nextPage);
         return;
       }
 
       const w = widthRef.current;
       if (w === 0 || reducedMotion) {
+        baseOffsetRef.current = 0;
+        committedPageRef.current = nextPage;
+        x.set(0);
         onCommitPage(nextPage);
         return;
       }
 
-      const dir: -1 | 1 = nextPage > currentPage ? 1 : -1;
+      const dir: -1 | 1 = nextPage > fromPage ? 1 : -1;
       setActiveTargetPage(nextPage);
       setActiveDirection(dir);
       directionRef.current = dir;
 
       const targetX = -dir * w;
+      inFlightRef.current = { target: nextPage, dir };
       animateTo(targetX, COMMIT_DURATION, () => {
+        baseOffsetRef.current = 0;
+        committedPageRef.current = nextPage;
+        inFlightRef.current = null;
         x.set(0);
         resetPreview();
         onCommitPage(nextPage);
       });
     },
-    [currentPage, pageCount, isAnimating, animateTo, onCommitPage, resetPreview, x, reducedMotion],
+    [pageCount, hardFinalizeInFlight, animateTo, onCommitPage, resetPreview, x, reducedMotion],
   );
 
   const bindPageDrag = useDrag(
@@ -177,18 +247,18 @@ export function useSheetPageMotion({
 
       if (isBlocked()) {
         cancel();
+        stopAnimation();
+        inFlightRef.current = null;
+        resetPreview();
         if (Math.abs(x.get()) > 0.5) {
-          resetPreview();
-          animateTo(0, SNAP_DURATION);
+          animateTo(0, SNAP_DURATION, () => {
+            baseOffsetRef.current = 0;
+          });
         } else {
-          resetPreview();
+          baseOffsetRef.current = 0;
+          x.set(0);
         }
         if (isDragging) setIsDragging(false);
-        return;
-      }
-
-      if (isAnimating) {
-        cancel();
         return;
       }
 
@@ -199,18 +269,25 @@ export function useSheetPageMotion({
       }
 
       if (first) {
-        stopAnimation();
+        // 진행 중 전환을 끊김 없이 이어받는다(있을 때만). 없으면 단순히 현 애니메이션 정지.
+        if (inFlightRef.current) {
+          finalizeInFlightForDrag();
+        } else {
+          stopAnimation();
+        }
         setIsDragging(true);
         onDragStart?.();
       }
 
+      // 인터럽트 직후엔 부모 currentPage가 아직 갱신 전이므로 committedPageRef 기준으로 계산.
+      const fromPage = committedPageRef.current;
       let intendedTarget: number | null = null;
       let intendedDir: -1 | 1 | null = null;
       if (mx < 0) {
-        intendedTarget = currentPage + 1;
+        intendedTarget = fromPage + 1;
         intendedDir = 1;
       } else if (mx > 0) {
-        intendedTarget = currentPage - 1;
+        intendedTarget = fromPage - 1;
         intendedDir = -1;
       }
 
@@ -234,7 +311,8 @@ export function useSheetPageMotion({
           directionRef.current = intendedDir;
           setActiveDirection(intendedDir);
         }
-        x.set(offset);
+        // baseOffset은 인터럽트로 이어받은 드래그의 시작 좌표(일반 드래그는 0).
+        x.set(baseOffsetRef.current + offset);
       }
 
       if (last) {
@@ -247,7 +325,9 @@ export function useSheetPageMotion({
 
         if (intendedTarget === null) {
           resetPreview();
-          animateTo(0, SNAP_DURATION);
+          animateTo(0, SNAP_DURATION, () => {
+            baseOffsetRef.current = 0;
+          });
           return;
         }
 
@@ -258,15 +338,22 @@ export function useSheetPageMotion({
         if (passesDistance || passesFlick) {
           const dir = intendedDir as -1 | 1;
           const committedTarget = intendedTarget;
+          // 스냅/커밋 목표는 현재 페이지의 표준 좌표계(홈=0, 다음=-dir*w) 기준.
           const targetX = -dir * w;
+          inFlightRef.current = { target: committedTarget, dir };
           animateTo(targetX, COMMIT_DURATION, () => {
+            baseOffsetRef.current = 0;
+            committedPageRef.current = committedTarget;
+            inFlightRef.current = null;
             x.set(0);
             resetPreview();
             onCommitPage(committedTarget);
           });
         } else {
           resetPreview();
-          animateTo(0, SNAP_DURATION);
+          animateTo(0, SNAP_DURATION, () => {
+            baseOffsetRef.current = 0;
+          });
         }
       }
     },

--- a/client/src/pages/CommandSetup.tsx
+++ b/client/src/pages/CommandSetup.tsx
@@ -41,7 +41,7 @@ export default function CommandSetup() {
   };
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -30,7 +30,7 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-4xl mx-auto">
         {/* 헤더 */}
         <div className="relative text-center mb-12">
@@ -46,8 +46,8 @@ export default function Home() {
             </Button>
           )}
           <img src="/pwa-192x192.png" alt="길튼 시스템" className="mx-auto w-24 h-24 rounded-3xl mb-6 shadow-sm" />
-          <h1 className="text-5xl font-bold text-foreground mb-3 tracking-tight">길튼 시스템</h1>
-          <p className="text-xl text-muted-foreground">예배 찬양 지원 시스템</p>
+          <h1 className="text-3xl sm:text-5xl font-bold text-foreground mb-3 tracking-tight">길튼 시스템</h1>
+          <p className="text-base sm:text-xl text-muted-foreground">예배 찬양 지원 시스템</p>
         </div>
 
         {/* 프로필 선택 */}

--- a/client/src/pages/PinLock.tsx
+++ b/client/src/pages/PinLock.tsx
@@ -19,7 +19,7 @@ export default function PinLock() {
   };
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-8">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4 sm:p-8">
       <Card className="rounded-3xl w-full max-w-sm">
         <CardContent className="p-8">
           <div className="text-center mb-8">

--- a/client/src/pages/ProfileEdit.tsx
+++ b/client/src/pages/ProfileEdit.tsx
@@ -58,7 +58,7 @@ export default function ProfileEdit() {
   };
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>

--- a/client/src/pages/ProfileSetup.tsx
+++ b/client/src/pages/ProfileSetup.tsx
@@ -13,7 +13,7 @@ export default function ProfileSetup() {
   const getRoleById = (roleId: string) => roles.find((r) => r.id === roleId);
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-3xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>

--- a/client/src/pages/RoleManagement.tsx
+++ b/client/src/pages/RoleManagement.tsx
@@ -59,7 +59,7 @@ export default function RoleManagement() {
   };
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -185,6 +185,8 @@ export default function Worship() {
 
   const shouldReduceMotion = useReducedMotion();
   const isLargeScreen = useMediaQuery("(min-width: 64rem)");
+  // 폰(< md): 좌/우 패널을 밀어내기 대신 오버레이 드로어로 동작시킨다.
+  const isMobile = !useMediaQuery("(min-width: 48rem)");
   const commandPanelWidth = isLargeScreen ? "20rem" : "11rem";
 
   const {
@@ -235,8 +237,21 @@ export default function Worship() {
     toast.success("현재 페이지를 호출했습니다");
   }, [id, currentProfileId, currentSheet, socket]);
 
-  const handleToggleSidebar = useCallback(() => setShowSidebar((s) => !s), []);
-  const handleToggleCommandPanel = useCallback(() => setShowCommandPanel((s) => !s), []);
+  // 모바일에선 한 쪽 드로어만 — 하나를 열면 다른 하나를 닫는다.
+  const handleToggleSidebar = useCallback(() => {
+    setShowSidebar((s) => {
+      const next = !s;
+      if (next && isMobile) setShowCommandPanel(false);
+      return next;
+    });
+  }, [isMobile]);
+  const handleToggleCommandPanel = useCallback(() => {
+    setShowCommandPanel((s) => {
+      const next = !s;
+      if (next && isMobile) setShowSidebar(false);
+      return next;
+    });
+  }, [isMobile]);
 
   const drawingTool: DrawingToolState = useMemo(
     () => ({ isDrawMode, selectedColor, penWidth, eraserType, eraserWidth, toolPopoverOpen }),
@@ -271,17 +286,28 @@ export default function Worship() {
         onToggleSidebar={handleToggleSidebar}
       />
 
-      {/* 컴팩트 모드: 연결 끊김 시 플로팅 인디케이터 */}
-      {isCompact && !isConnected && (
+      {/* 컴팩트 모드 또는 모바일(헤더 칩 숨김): 연결 끊김 시 플로팅 인디케이터 */}
+      {(isCompact || isMobile) && !isConnected && (
         <div className="absolute top-3 right-3 z-50 flex items-center gap-2 px-3 py-1.5 bg-red-600/20 border border-red-500/30 rounded-lg backdrop-blur-sm">
           <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
           <span className="text-xs font-medium text-red-400">연결 끊김</span>
         </div>
       )}
 
-      <div className="flex-1 flex overflow-hidden">
+      <div className="flex-1 flex overflow-hidden relative">
+        {/* 모바일: 패널 열림 시 배경을 탭하면 닫힘 */}
+        {isMobile && (showSidebar || showCommandPanel) && (
+          <div
+            className="absolute inset-0 z-30 bg-black/40"
+            onClick={() => {
+              setShowSidebar(false);
+              setShowCommandPanel(false);
+            }}
+          />
+        )}
         <SheetListSidebar
           show={showSidebar}
+          isMobile={isMobile}
           reducedMotion={!!shouldReduceMotion}
           sheets={sheets}
           currentSheetId={currentSheetId}
@@ -415,6 +441,7 @@ export default function Worship() {
 
         <CommandPanel
           show={showCommandPanel}
+          isMobile={isMobile}
           width={commandPanelWidth}
           reducedMotion={!!shouldReduceMotion}
           commands={commands}

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -78,25 +78,29 @@ function SortableSheetItem({
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Translate.toString(transform), transition }}
-      className={`bg-card rounded-xl p-4 border-2 transition-colors ${
+      className={`bg-card rounded-xl p-3 sm:p-4 border-2 transition-colors ${
         isDragging ? "opacity-30 border-dashed border-border" : "border-border hover:border-primary/40 hover:shadow-md"
       }`}
     >
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-2 sm:gap-4">
         <div
           {...attributes}
           {...listeners}
-          className="cursor-grab active:cursor-grabbing min-h-11 min-w-11 flex items-center justify-center hover:bg-accent rounded-lg transition-colors touch-none"
+          className="cursor-grab active:cursor-grabbing min-h-11 min-w-11 shrink-0 flex items-center justify-center hover:bg-accent rounded-lg transition-colors touch-none"
         >
           <GripVertical className="w-5 h-5 text-muted-foreground" />
         </div>
 
         {/* 이미지 미리보기 */}
-        <div className="relative">
+        <div className="relative shrink-0">
+          {/* 폰: 번호 칸 대신 썸네일 모서리 배지로 표시(데스크톱은 우측 번호 칸 유지) */}
+          <div className="sm:hidden absolute top-1 left-1 z-10 min-w-5 h-5 px-1 rounded-md bg-black/70 text-white text-xs font-bold flex items-center justify-center">
+            {index + 1}
+          </div>
           {sheet.imagePath ? (
             <Dialog>
               <DialogTrigger asChild>
-                <div className="relative w-20 h-24 rounded-lg overflow-hidden border-2 border-border cursor-pointer shadow-md">
+                <div className="relative w-16 h-20 sm:w-20 sm:h-24 rounded-lg overflow-hidden border-2 border-border cursor-pointer shadow-md">
                   <img src={`/uploads/${sheet.imagePath}`} alt={sheet.title} className="w-full h-full object-cover" />
                   <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/60 to-transparent p-2 flex items-center justify-center">
                     <Eye className="w-4 h-4 text-white" />
@@ -116,7 +120,7 @@ function SortableSheetItem({
               </DialogContent>
             </Dialog>
           ) : (
-            <div className="w-20 h-24 bg-muted rounded-lg flex items-center justify-center text-3xl border-2 border-border">
+            <div className="w-16 h-20 sm:w-20 sm:h-24 bg-muted rounded-lg flex items-center justify-center text-3xl border-2 border-border">
               📄
             </div>
           )}
@@ -156,14 +160,14 @@ function SortableSheetItem({
             </div>
           ) : (
             <>
-              <div className="flex items-center gap-2">
-                <div className="font-semibold text-foreground line-clamp-2">{sheet.title}</div>
+              <div className="flex items-center gap-1 sm:gap-2">
+                <div className="flex-1 min-w-0 font-semibold text-foreground line-clamp-2">{sheet.title}</div>
                 <Button
                   variant="ghost"
                   size="icon"
                   onClick={() => onEdit(sheet.id, sheet.title)}
                   title="제목 수정"
-                  className="min-h-11 min-w-11 text-primary hover:bg-accent"
+                  className="min-h-11 min-w-11 shrink-0 text-primary hover:bg-accent"
                 >
                   <Pencil className="w-3.5 h-3.5" />
                 </Button>
@@ -173,7 +177,9 @@ function SortableSheetItem({
           )}
         </div>
 
-        <div className="text-2xl font-bold text-muted-foreground min-w-10 shrink-0 text-center">{index + 1}</div>
+        <div className="hidden sm:block text-2xl font-bold text-muted-foreground min-w-10 shrink-0 text-center">
+          {index + 1}
+        </div>
 
         {!isEditing && (
           <ConfirmDialog
@@ -413,7 +419,7 @@ export default function WorshipEdit() {
 
         {/* 예배 정보 */}
         <Card className="mb-6">
-          <CardContent>
+          <CardContent className="px-3 sm:px-6">
             <h2 className="text-xl font-bold text-foreground mb-6">예배 정보</h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -492,7 +498,7 @@ export default function WorshipEdit() {
 
         {/* 악보 업로드 섹션 */}
         <Card className="mb-6">
-          <CardContent>
+          <CardContent className="px-3 sm:px-6">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
               <div>
                 <h2 className="text-xl font-bold text-foreground">악보 관리</h2>

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -123,7 +123,7 @@ function SortableSheetItem({
         </div>
 
         {/* 제목 편집 영역 */}
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
           {isEditing ? (
             <div className="space-y-2">
               <Input
@@ -173,7 +173,7 @@ function SortableSheetItem({
           )}
         </div>
 
-        <div className="text-2xl font-bold text-muted-foreground min-w-10 text-center">{index + 1}</div>
+        <div className="text-2xl font-bold text-muted-foreground min-w-10 shrink-0 text-center">{index + 1}</div>
 
         {!isEditing && (
           <ConfirmDialog
@@ -391,20 +391,23 @@ export default function WorshipEdit() {
   };
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-5xl mx-auto">
         {/* 헤더 */}
-        <div className="flex items-center gap-4 mb-8">
-          <Button variant="outline" size="icon" onClick={() => navigate(-1)}>
+        <div className="flex items-center gap-3 sm:gap-4 mb-6 sm:mb-8">
+          <Button variant="outline" size="icon" className="shrink-0" onClick={() => navigate(-1)}>
             <ArrowLeft className="w-6 h-6" />
           </Button>
-          <div className="flex-1">
-            <h1 className="text-3xl font-bold text-foreground">{isNew ? "새 예배 만들기" : "예배 편집"}</h1>
-            <p className="text-muted-foreground">예배 정보와 악보를 관리하세요</p>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground truncate">
+              {isNew ? "새 예배 만들기" : "예배 편집"}
+            </h1>
+            <p className="text-sm sm:text-base text-muted-foreground">예배 정보와 악보를 관리하세요</p>
           </div>
-          <Button onClick={handleSave} disabled={saving}>
+          <Button onClick={handleSave} disabled={saving} className="shrink-0">
             <Save className="w-5 h-5" />
-            {saving ? "저장 중..." : "저장하기"}
+            <span className="hidden sm:inline">{saving ? "저장 중..." : "저장하기"}</span>
+            <span className="sm:hidden">{saving ? "저장 중" : "저장"}</span>
           </Button>
         </div>
 
@@ -490,14 +493,14 @@ export default function WorshipEdit() {
         {/* 악보 업로드 섹션 */}
         <Card className="mb-6">
           <CardContent>
-            <div className="flex items-center justify-between mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
               <div>
                 <h2 className="text-xl font-bold text-foreground">악보 관리</h2>
                 <p className="text-sm text-muted-foreground mt-1">
                   드래그하여 순서를 변경하거나 제목을 수정할 수 있습니다
                 </p>
               </div>
-              <Button onClick={() => fileInputRef.current?.click()}>
+              <Button onClick={() => fileInputRef.current?.click()} className="w-full sm:w-auto">
                 <Upload className="w-5 h-5" />
                 악보 추가
               </Button>
@@ -573,30 +576,6 @@ export default function WorshipEdit() {
             )}
           </CardContent>
         </Card>
-
-        {/* 통계 카드 */}
-        <div className="grid grid-cols-3 gap-4">
-          <Card className="bg-accent shadow-none">
-            <CardContent>
-              <div className="text-sm font-semibold text-accent-foreground mb-1">총 악보</div>
-              <div className="text-3xl font-bold text-primary">{sheets.length}개</div>
-            </CardContent>
-          </Card>
-          <Card className="bg-accent shadow-none">
-            <CardContent>
-              <div className="text-sm font-semibold text-accent-foreground mb-1">예배 날짜</div>
-              <div className="text-xl font-bold text-primary">{date || "미정"}</div>
-            </CardContent>
-          </Card>
-          <Card className="bg-accent shadow-none">
-            <CardContent>
-              <div className="text-sm font-semibold text-accent-foreground mb-1">상태</div>
-              <div className="text-xl font-bold text-primary">
-                {title && date && sheets.length > 0 ? "준비완료" : "작성중"}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
       </div>
     </div>
   );

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -160,18 +160,7 @@ function SortableSheetItem({
             </div>
           ) : (
             <>
-              <div className="flex items-center gap-1 sm:gap-2">
-                <div className="flex-1 min-w-0 font-semibold text-foreground line-clamp-2">{sheet.title}</div>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onEdit(sheet.id, sheet.title)}
-                  title="제목 수정"
-                  className="min-h-11 min-w-11 shrink-0 text-primary hover:bg-accent"
-                >
-                  <Pencil className="w-3.5 h-3.5" />
-                </Button>
-              </div>
+              <div className="font-semibold text-foreground line-clamp-2">{sheet.title}</div>
               <div className="text-sm text-muted-foreground mt-1 truncate">{sheet.fileName}</div>
             </>
           )}
@@ -181,19 +170,35 @@ function SortableSheetItem({
           {index + 1}
         </div>
 
+        {/* 수정·삭제 액션 묶음 — 같은 행 직계 자식 + 동일 크기로 세로 정렬 일치 */}
         {!isEditing && (
-          <ConfirmDialog
-            trigger={
-              <Button variant="ghost" size="icon" className="text-destructive hover:bg-destructive/10">
-                <Trash2 className="w-5 h-5" />
-              </Button>
-            }
-            title="악보 삭제"
-            description="이 악보를 삭제하시겠습니까?"
-            confirmLabel="삭제"
-            onConfirm={() => onDelete(sheet.id)}
-            destructive
-          />
+          <div className="flex items-center shrink-0">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onEdit(sheet.id, sheet.title)}
+              title="제목 수정"
+              className="min-h-11 min-w-11 text-primary hover:bg-accent"
+            >
+              <Pencil className="w-4 h-4" />
+            </Button>
+            <ConfirmDialog
+              trigger={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="min-h-11 min-w-11 text-destructive hover:bg-destructive/10"
+                >
+                  <Trash2 className="w-5 h-5" />
+                </Button>
+              }
+              title="악보 삭제"
+              description="이 악보를 삭제하시겠습니까?"
+              confirmLabel="삭제"
+              onConfirm={() => onDelete(sheet.id)}
+              destructive
+            />
+          </div>
         )}
       </div>
     </div>

--- a/client/src/pages/WorshipList.tsx
+++ b/client/src/pages/WorshipList.tsx
@@ -1,14 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import { Plus, Calendar, Music, Edit, Trash2, Play, ArrowLeft, Filter, X } from "lucide-react";
-import {
-  useWorships,
-  useWorshipYears,
-  useWorshipTypes,
-  useDeleteWorship,
-  useProfiles,
-  useRoles,
-} from "@/hooks/queries";
+import { useWorships, useWorshipYears, useWorshipTypes, useDeleteWorship } from "@/hooks/queries";
 import { useAppStore } from "@/store/appStore";
 import { getColorOption } from "@/lib/colors";
 import { Button } from "@/components/ui/button";
@@ -20,8 +13,6 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 export default function WorshipList() {
   const { data: worshipTypes = [] } = useWorshipTypes();
-  const { data: profiles = [] } = useProfiles();
-  const { data: roles = [] } = useRoles();
   const { data: availableYears = [] } = useWorshipYears();
   const deleteWorshipMutation = useDeleteWorship();
   const currentProfileId = useAppStore((s) => s.currentProfileId);
@@ -48,7 +39,6 @@ export default function WorshipList() {
   });
 
   const worships = data?.pages.flatMap((p) => p.items) ?? [];
-  const total = data?.pages[0]?.total ?? 0;
 
   // 프로필 미선택 시 홈으로 리다이렉트
   useEffect(() => {
@@ -84,9 +74,6 @@ export default function WorshipList() {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const currentProfile = profiles.find((p) => p.id === currentProfileId);
-  const currentRole = currentProfile ? roles.find((r) => r.id === currentProfile.roleId) : undefined;
-
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString("ko-KR", {
@@ -108,35 +95,24 @@ export default function WorshipList() {
   const hasActiveFilter = !!(debouncedQuery || selectedTypeId || selectedYear);
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-5xl mx-auto">
         {/* 헤더 */}
-        <div className="flex items-center gap-4 mb-8">
-          <Button variant="outline" size="icon" asChild>
+        <div className="flex items-center gap-3 sm:gap-4 mb-6 sm:mb-8">
+          <Button variant="outline" size="icon" className="shrink-0" asChild>
             <Link to="/">
               <ArrowLeft className="w-6 h-6" />
             </Link>
           </Button>
-          <div className="flex-1">
-            <h1 className="text-3xl font-bold text-foreground">예배 목록</h1>
-            <p className="text-muted-foreground">예배를 선택하거나 새로운 예배를 만드세요</p>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground truncate">예배 목록</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">예배를 선택하거나 새로운 예배를 만드세요</p>
           </div>
-          {currentProfile && (
-            <div className="flex items-center gap-3 px-5 py-3 bg-card rounded-xl shadow-sm border-2 border-border">
-              <div
-                className={`w-10 h-10 ${currentProfile.color} rounded-full flex items-center justify-center text-xl`}
-              >
-                {currentRole?.icon}
-              </div>
-              <div>
-                <div className="text-sm font-semibold text-foreground">{currentProfile.name}</div>
-                <div className="text-xs text-muted-foreground">{currentRole?.name}</div>
-              </div>
-            </div>
-          )}
-          <Button asChild>
+          <Button className="shrink-0" asChild>
             <Link to="/worship-edit/new">
-              <Plus className="w-5 h-5" />새 예배 만들기
+              <Plus className="w-5 h-5" />
+              <span className="hidden sm:inline">새 예배 만들기</span>
+              <span className="sm:hidden">새 예배</span>
             </Link>
           </Button>
         </div>
@@ -271,16 +247,16 @@ export default function WorshipList() {
             return (
               <Card
                 key={worship.id}
-                className="p-6 border-2 border-transparent hover:border-primary/40 transition-all hover:shadow-md"
+                className="p-4 sm:p-6 border-2 border-transparent hover:border-primary/40 transition-all hover:shadow-md"
               >
                 <CardContent className="p-0">
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1">
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                    <div className="flex-1 min-w-0">
                       <div className="mb-3">
-                        <h3 className="text-xl font-bold text-foreground">{worship.title}</h3>
-                        <div className="flex items-center gap-3 mt-2">
+                        <h3 className="text-lg sm:text-xl font-bold text-foreground">{worship.title}</h3>
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2">
                           <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                            <Calendar className="w-4 h-4" />
+                            <Calendar className="w-4 h-4 shrink-0" />
                             {formatDate(worship.date)}
                           </div>
                           <div className="text-sm text-muted-foreground">악보 {worship.sheets?.length ?? 0}개</div>
@@ -299,7 +275,7 @@ export default function WorshipList() {
                       </div>
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 shrink-0">
                       <Button asChild>
                         <Link to={`/worship/${worship.id}`}>
                           <Play className="w-5 h-5" />
@@ -366,30 +342,6 @@ export default function WorshipList() {
               )}
             </CardContent>
           </Card>
-        )}
-
-        {/* 통계 */}
-        {total > 0 && (
-          <div className="mt-6 grid grid-cols-3 gap-4">
-            <Card className="bg-accent p-6">
-              <CardContent className="p-0">
-                <div className="text-sm font-semibold text-accent-foreground mb-1">전체 예배</div>
-                <div className="text-3xl font-bold text-primary">{total}개</div>
-              </CardContent>
-            </Card>
-            <Card className="bg-accent p-6">
-              <CardContent className="p-0">
-                <div className="text-sm font-semibold text-accent-foreground mb-1">불러온 예배</div>
-                <div className="text-3xl font-bold text-primary">{worships.length}개</div>
-              </CardContent>
-            </Card>
-            <Card className="bg-accent p-6">
-              <CardContent className="p-0">
-                <div className="text-sm font-semibold text-accent-foreground mb-1">예배 유형</div>
-                <div className="text-3xl font-bold text-primary">{worshipTypes.length}개</div>
-              </CardContent>
-            </Card>
-          </div>
         )}
       </div>
     </div>

--- a/client/src/pages/WorshipTypeSettings.tsx
+++ b/client/src/pages/WorshipTypeSettings.tsx
@@ -57,7 +57,7 @@ export default function WorshipTypeSettings() {
   };
 
   return (
-    <div className="min-h-screen bg-background p-8">
+    <div className="min-h-screen bg-background p-4 sm:p-8">
       <div className="max-w-5xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>


### PR DESCRIPTION
## 배경

`develop` 기준 작업. 아이패드 최적화 길튼 시스템의 두 가지 아쉬운 점 + UI 피드백을 반영합니다.

1. **빠른 연속 스와이프가 끊김** — 1→2 전환 애니메이션(240ms)이 끝나야 다음 스와이프가 먹어, 빠르게 1→2→3로 넘기면 두 번째 플릭이 버려졌습니다.
2. **태블릿 전용 UI** — 실사용은 태블릿이지만 악보 업로드는 폰으로 많이 하므로 폰 화면 대응이 필요했습니다.

## 변경 내용

### 1. 끊김 없는 연속 스와이프 (`useSheetPageMotion.ts`)
- 애니메이션 중 새 제스처를 `cancel()`로 차단하던 `isAnimating` 게이트 제거
- 진행 중이던 커밋을 **base offset 재앵커**로 즉시 확정 → 들어오던 미리보기 카드를 같은 위치에 두고 새 드래그를 점프 없이 이어받음
- `committedPageRef`로 부모 `currentPage`의 비동기 갱신 지연(staleness) 보정
- 플릭 임계값·클릭 서프레션·핀치/줌 가드·snap-back 동작은 그대로 유지

### 2. 모바일 반응형 (develop의 분리된 뷰어 컴포넌트에 적용)
- **악보 뷰어 좌/우 패널**(`SheetListSidebar`·`CommandPanel`): 폰(`< 48rem`)에서 밀어내기 대신 **오버레이 드로어 + 반투명 backdrop**으로 전환, 상호 배타. 태블릿 이상은 기존 동작 유지(회귀 없음)
- `WorshipHeader`/`DrawingToolbar`: 좁은 폭 패딩·라벨·overflow 정리
- 관리/업로드 페이지: 컨테이너 패딩 `p-4 sm:p-8`, 헤더 `flex-col sm:flex-row` 스택, 타이포·카드 레이아웃 반응형. 캔버스 좌표/DPR 로직은 미변경

### 3. UI 피드백 반영
- 예배 목록·예배 편집 **하단 통계 카드 3개 제거**
- 예배 목록 **상단 프로필 칩 제거**
- 예배 편집 악보 행: **번호가 프레임 밖으로 삐져나가던 문제 수정** — 폰은 번호를 썸네일 좌상단 배지로, 데스크톱은 기존 우측 번호 칸 유지
- 악보 행 **수정·삭제 버튼 정렬/크기 통일**(같은 액션 묶음 + `min-h-11`)

## 검증
- `npm run check`(타입체크 + ESLint + prettier) 통과 (warning 0)
- Playwright + Chromium 실구동: 아이패드(834×1194) 빠른 연속 스와이프 `1/4→2/4→4/4` 드롭·점프 없음 / 폰(390·360) 드로어·악보 행 레이아웃 확인 / 데스크톱 회귀 없음