### PR TITLE
Refactor Worship page: extract components & add infinite scroll

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "idb-keyval": "^6.2.2",
         "lucide-react": "^0.576.0",
         "motion": "^12.38.0",
+        "pretendard": "^1.3.9",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -12359,6 +12360,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "idb-keyval": "^6.2.2",
     "lucide-react": "^0.576.0",
     "motion": "^12.38.0",
+    "pretendard": "^1.3.9",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/client/src/components/SheetCanvas.tsx
+++ b/client/src/components/SheetCanvas.tsx
@@ -514,10 +514,10 @@ function SheetCanvas({
       />
 
       {!imageUrl && (
-        <div className="absolute inset-0 flex items-center justify-center bg-linear-to-br from-amber-50 to-orange-50 pointer-events-none">
+        <div className="absolute inset-0 flex items-center justify-center bg-muted pointer-events-none">
           <div className="text-center">
             <div className="text-6xl mb-4">📄</div>
-            <p className="text-xl text-slate-500">악보를 업로드하세요</p>
+            <p className="text-xl text-muted-foreground">악보를 업로드하세요</p>
           </div>
         </div>
       )}

--- a/client/src/components/SheetCanvas.tsx
+++ b/client/src/components/SheetCanvas.tsx
@@ -14,7 +14,7 @@ import {
 
 export type EraserType = "none" | "area" | "stroke";
 
-interface RemoteInProgressPath {
+export interface RemoteInProgressPath {
   pathId: string;
   profileId: string;
   color: string;

--- a/client/src/components/SheetCanvas.tsx
+++ b/client/src/components/SheetCanvas.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useLayoutEffect, useRef, useCallback, useState } from "react";
 import type { DrawingPath, Point } from "@/hooks/useDrawingSync";
+import {
+  FALLBACK_SHEET_ASPECT,
+  denormalizePoint,
+  normalizePoint,
+  clamp01,
+  getContainedRect,
+  getCanvasContentRect,
+  syncCanvasBackingStore,
+  distanceToSegment,
+  generateId,
+} from "@/lib/canvas";
 
 export type EraserType = "none" | "area" | "stroke";
 
@@ -29,70 +40,6 @@ interface SheetCanvasProps {
   onBatchStart?: () => void;
   onBatchEnd?: () => void;
   profileId: string;
-}
-
-interface ContentRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-const FALLBACK_SHEET_ASPECT = 3 / 4;
-const EMPTY_RECT: ContentRect = { x: 0, y: 0, width: 0, height: 0 };
-
-// 정규화 좌표 → 화면 좌표
-function denormalizePoint(p: Point, rect: ContentRect): { x: number; y: number } {
-  return { x: rect.x + p.x * rect.width, y: rect.y + p.y * rect.height };
-}
-
-// 화면 좌표 → 정규화 좌표
-function normalizePoint(x: number, y: number, rect: ContentRect): Point {
-  return { x: (x - rect.x) / rect.width, y: (y - rect.y) / rect.height };
-}
-
-function clamp01(value: number): number {
-  return Math.max(0, Math.min(1, value));
-}
-
-function getContainedRect(containerWidth: number, containerHeight: number, aspect: number): ContentRect {
-  if (containerWidth <= 0 || containerHeight <= 0 || aspect <= 0) return EMPTY_RECT;
-
-  const containerAspect = containerWidth / containerHeight;
-  if (containerAspect > aspect) {
-    const width = containerHeight * aspect;
-    return { x: (containerWidth - width) / 2, y: 0, width, height: containerHeight };
-  }
-
-  const height = containerWidth / aspect;
-  return { x: 0, y: (containerHeight - height) / 2, width: containerWidth, height };
-}
-
-// 그리기/정규화의 기준이 되는 CSS-space content rect. 좌표·굵기 계산은 모두 CSS px 기준이어야 하므로
-// backing store 픽셀(canvas.width, DPR배)이 아닌 레이아웃 크기(offsetWidth/Height)를 단일 기준으로 고정한다.
-// 한 call site라도 canvas.width로 되돌아가면 DPR배 오차가 나므로 helper로 묶어 불변식을 강제한다.
-function getCanvasContentRect(canvas: HTMLCanvasElement, imageAspect: number | null): ContentRect {
-  return getContainedRect(canvas.offsetWidth, canvas.offsetHeight, imageAspect ?? FALLBACK_SHEET_ASPECT);
-}
-
-// backing store를 CSS 레이아웃 크기 × DPR로 동기화 (실제로 다를 때만 — 재설정 시 canvas가 클리어됨).
-// 사용한 dpr을 반환 — 호출부가 ctx.setTransform(dpr,…)로 좌표계를 CSS px로 통일한다.
-// ResizeObserver 경로와 redraw 경로가 같은 계산을 쓰도록 한곳에 모은다.
-function syncCanvasBackingStore(canvas: HTMLCanvasElement): number {
-  const dpr = window.devicePixelRatio || 1;
-  const cssW = canvas.offsetWidth;
-  const cssH = canvas.offsetHeight;
-  const bufW = Math.round(cssW * dpr);
-  const bufH = Math.round(cssH * dpr);
-  if (cssW > 0 && cssH > 0 && (canvas.width !== bufW || canvas.height !== bufH)) {
-    canvas.width = bufW;
-    canvas.height = bufH;
-  }
-  return dpr;
-}
-
-function generateId(): string {
-  return Math.random().toString(36).substring(2, 11);
 }
 
 export default function SheetCanvas({
@@ -376,26 +323,6 @@ export default function SheetCanvas({
     },
     [imageAspect], // pathsRef로 참조하므로 paths 의존성 불필요
   );
-
-  const distanceToSegment = (
-    point: { x: number; y: number },
-    p1: { x: number; y: number },
-    p2: { x: number; y: number },
-  ): number => {
-    const dx = p2.x - p1.x;
-    const dy = p2.y - p1.y;
-    if (dx === 0 && dy === 0) {
-      const pdx = point.x - p1.x;
-      const pdy = point.y - p1.y;
-      return Math.sqrt(pdx * pdx + pdy * pdy);
-    }
-    const t = Math.max(0, Math.min(1, ((point.x - p1.x) * dx + (point.y - p1.y) * dy) / (dx * dx + dy * dy)));
-    const projX = p1.x + t * dx;
-    const projY = p1.y + t * dy;
-    const pdx = point.x - projX;
-    const pdy = point.y - projY;
-    return Math.sqrt(pdx * pdx + pdy * pdy);
-  };
 
   // 진행 중인 그리기 취소
   const cancelDrawing = () => {

--- a/client/src/components/SheetCanvas.tsx
+++ b/client/src/components/SheetCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useCallback, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useCallback, useState } from "react";
 import type { DrawingPath, Point } from "@/hooks/useDrawingSync";
 import {
   FALLBACK_SHEET_ASPECT,
@@ -42,7 +42,7 @@ interface SheetCanvasProps {
   profileId: string;
 }
 
-export default function SheetCanvas({
+function SheetCanvas({
   sheetId,
   imageUrl,
   isDrawMode,
@@ -524,3 +524,7 @@ export default function SheetCanvas({
     </div>
   );
 }
+
+// 부모(Worship) 리렌더(presence/navbar/compact 등)가 잦으므로 memo로 감싼다.
+// props 콜백은 useDrawingSync에서 useCallback으로 안정화돼 있어 memo가 실효를 가진다.
+export default memo(SheetCanvas);

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -9,19 +9,19 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-blue-600 text-white hover:bg-blue-700 shadow-lg",
-        destructive: "bg-red-50 text-red-600 hover:bg-red-100",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
+        destructive: "bg-destructive/10 text-destructive hover:bg-destructive/15",
         outline:
-          "border-2 border-slate-200 bg-white text-slate-700 hover:bg-slate-50 shadow-md",
-        secondary: "bg-slate-100 text-slate-700 hover:bg-slate-200",
-        ghost: "hover:bg-slate-100 text-slate-600",
-        link: "text-blue-600 underline-offset-4 hover:underline",
+          "border-2 border-border bg-card text-foreground hover:bg-accent",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent text-muted-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "px-6 py-3 rounded-xl",
-        sm: "px-4 py-2 rounded-lg text-sm",
-        lg: "px-8 py-4 rounded-xl text-lg",
-        icon: "p-3 rounded-xl",
+        default: "px-6 py-3 rounded-lg",
+        sm: "px-4 py-2 rounded-md text-sm min-h-11",
+        lg: "px-8 py-4 rounded-lg text-lg",
+        icon: "p-3 rounded-lg",
       },
     },
     defaultVariants: {

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-white text-card-foreground flex flex-col gap-6 rounded-2xl py-6 shadow-xl",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl py-6 border border-border shadow-sm",
         className
       )}
       {...props}

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -8,8 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground w-full min-w-0 rounded-xl border-2 border-slate-200 bg-slate-50 px-5 py-4 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        "focus:border-blue-500",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground w-full min-w-0 rounded-lg border-2 border-input bg-background px-5 py-4 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "focus:border-ring focus:ring-2 focus:ring-ring/30",
         "aria-invalid:border-destructive",
         className
       )}

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -1,0 +1,188 @@
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/70 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-11 data-[size=sm]:h-11 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full min-h-12 cursor-default items-center gap-2 rounded-sm py-2 pr-8 pl-2 text-base outline-hidden select-none focus:bg-primary focus:text-primary-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex min-h-11 cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex min-h-11 cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/client/src/components/worship/CommandPanel.tsx
+++ b/client/src/components/worship/CommandPanel.tsx
@@ -21,7 +21,7 @@ function CommandPanel({ show, width, reducedMotion, commands, onSendCommand }: C
       initial={false}
       animate={show ? { width, opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: 12 }}
       transition={reducedMotion ? { duration: 0 } : panelTransition}
-      className={cn("shrink-0 bg-slate-800 overflow-hidden", show && "border-l border-slate-700")}
+      className={cn("shrink-0 bg-viewer-panel overflow-hidden", show && "border-l border-viewer-border")}
       style={{ pointerEvents: show ? "auto" : "none" }}
     >
       <motion.div
@@ -30,16 +30,16 @@ function CommandPanel({ show, width, reducedMotion, commands, onSendCommand }: C
         className="h-full overflow-y-auto p-4 box-border"
         style={{ width }}
       >
-        <h2 className="text-lg font-bold text-white mb-4">명령 전송</h2>
+        <h2 className="text-lg font-bold text-viewer-foreground mb-4">명령 전송</h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
           {commands.map((command) => (
             <button
               key={command.id}
               onClick={() => onSendCommand(command)}
-              className="flex flex-col items-center gap-2 p-6 bg-slate-700 hover:bg-slate-600 rounded-2xl transition-all active:scale-95 group"
+              className="flex flex-col items-center gap-2 p-6 bg-white/5 hover:bg-white/10 rounded-2xl transition-all active:scale-95 group"
             >
               <span className="text-5xl group-hover:scale-110 transition-transform">{command.emoji}</span>
-              <span className="text-sm font-semibold text-slate-300 text-center">{command.label}</span>
+              <span className="text-sm font-semibold text-viewer-muted text-center">{command.label}</span>
             </button>
           ))}
         </div>

--- a/client/src/components/worship/CommandPanel.tsx
+++ b/client/src/components/worship/CommandPanel.tsx
@@ -1,0 +1,51 @@
+import { memo } from "react";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
+import type { Command } from "@/types";
+import { panelTransition, panelContentTransition } from "./panelMotion";
+
+interface CommandPanelProps {
+  show: boolean;
+  width: string;
+  reducedMotion: boolean;
+  commands: Command[];
+  onSendCommand: (command: Command) => void;
+}
+
+// 우측 명령 전송 패널 (슬라이드 인/아웃).
+function CommandPanel({ show, width, reducedMotion, commands, onSendCommand }: CommandPanelProps) {
+  return (
+    <motion.aside
+      aria-hidden={!show}
+      inert={!show}
+      initial={false}
+      animate={show ? { width, opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: 12 }}
+      transition={reducedMotion ? { duration: 0 } : panelTransition}
+      className={cn("shrink-0 bg-slate-800 overflow-hidden", show && "border-l border-slate-700")}
+      style={{ pointerEvents: show ? "auto" : "none" }}
+    >
+      <motion.div
+        animate={show ? { opacity: 1, x: 0 } : { opacity: 0, x: 8 }}
+        transition={reducedMotion ? { duration: 0 } : panelContentTransition}
+        className="h-full overflow-y-auto p-4 box-border"
+        style={{ width }}
+      >
+        <h2 className="text-lg font-bold text-white mb-4">명령 전송</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          {commands.map((command) => (
+            <button
+              key={command.id}
+              onClick={() => onSendCommand(command)}
+              className="flex flex-col items-center gap-2 p-6 bg-slate-700 hover:bg-slate-600 rounded-2xl transition-all active:scale-95 group"
+            >
+              <span className="text-5xl group-hover:scale-110 transition-transform">{command.emoji}</span>
+              <span className="text-sm font-semibold text-slate-300 text-center">{command.label}</span>
+            </button>
+          ))}
+        </div>
+      </motion.div>
+    </motion.aside>
+  );
+}
+
+export default memo(CommandPanel);

--- a/client/src/components/worship/CommandToast.tsx
+++ b/client/src/components/worship/CommandToast.tsx
@@ -10,13 +10,13 @@ interface CommandToastProps {
 export default function CommandToast({ emoji, label, senderName, senderRoleIcon, onDismiss }: CommandToastProps) {
   return (
     <div
-      className="bg-white rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-blue-500 cursor-pointer"
+      className="bg-card rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-primary cursor-pointer"
       onClick={onDismiss}
     >
       <div className="text-6xl">{emoji}</div>
       <div className="flex-1">
-        <div className="text-2xl font-bold text-slate-800">{label}</div>
-        <div className="flex items-center gap-2 text-sm text-slate-500 mt-1">
+        <div className="text-2xl font-bold text-foreground">{label}</div>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground mt-1">
           <span className="text-lg">{senderRoleIcon}</span>
           <span className="font-semibold">{senderName}</span>
           <span>님이 전송</span>

--- a/client/src/components/worship/CommandToast.tsx
+++ b/client/src/components/worship/CommandToast.tsx
@@ -1,0 +1,27 @@
+interface CommandToastProps {
+  emoji: string;
+  label: string;
+  senderName: string;
+  senderRoleIcon: string;
+  onDismiss: () => void;
+}
+
+// command:received 수신 시 표시하는 토스트 카드 (탭하면 닫힘).
+export default function CommandToast({ emoji, label, senderName, senderRoleIcon, onDismiss }: CommandToastProps) {
+  return (
+    <div
+      className="bg-white rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-blue-500 cursor-pointer"
+      onClick={onDismiss}
+    >
+      <div className="text-6xl">{emoji}</div>
+      <div className="flex-1">
+        <div className="text-2xl font-bold text-slate-800">{label}</div>
+        <div className="flex items-center gap-2 text-sm text-slate-500 mt-1">
+          <span className="text-lg">{senderRoleIcon}</span>
+          <span className="font-semibold">{senderName}</span>
+          <span>님이 전송</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -1,0 +1,317 @@
+import { memo, type Dispatch, type SetStateAction } from "react";
+import { Pencil, Eye, Eraser, Undo, Redo, Minus, Plus as PlusIcon, Trash, Megaphone, Palette } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { EraserType } from "@/components/SheetCanvas";
+
+export interface DrawingToolState {
+  isDrawMode: boolean;
+  selectedColor: string;
+  penWidth: number;
+  eraserType: EraserType;
+  eraserWidth: number;
+  toolPopoverOpen: boolean;
+}
+
+export interface DrawingToolActions {
+  setIsDrawMode: (v: boolean) => void;
+  setSelectedColor: (v: string) => void;
+  setPenWidth: Dispatch<SetStateAction<number>>;
+  setEraserType: Dispatch<SetStateAction<EraserType>>;
+  setEraserWidth: Dispatch<SetStateAction<number>>;
+  setToolPopoverOpen: (v: boolean) => void;
+  undo: () => void;
+  redo: () => void;
+  setIsCompact: (v: boolean) => void;
+}
+
+interface PenColor {
+  color: string;
+  value: string;
+}
+
+interface DrawingToolbarProps {
+  isCompact: boolean;
+  tool: DrawingToolState;
+  actions: DrawingToolActions;
+  hasSheet: boolean;
+  showCommandPanel: boolean;
+  penColors: PenColor[];
+  onToggleCommandPanel: () => void;
+  onSpotlightCall: () => void;
+}
+
+// 도구 바 (컴팩트 시 세로 콜랩스 + 페이드). 모드 전환·도구 팝오버·실행취소·호출·명령 패널 토글.
+function DrawingToolbar({
+  isCompact,
+  tool,
+  actions,
+  hasSheet,
+  showCommandPanel,
+  penColors,
+  onToggleCommandPanel,
+  onSpotlightCall,
+}: DrawingToolbarProps) {
+  const { isDrawMode, selectedColor, penWidth, eraserType, eraserWidth, toolPopoverOpen } = tool;
+  const {
+    setIsDrawMode,
+    setSelectedColor,
+    setPenWidth,
+    setEraserType,
+    setEraserWidth,
+    setToolPopoverOpen,
+    undo,
+    redo,
+    setIsCompact,
+  } = actions;
+
+  return (
+    <div
+      className="grid"
+      style={{
+        gridTemplateRows: isCompact ? "0fr" : "1fr",
+        transition: "grid-template-rows var(--dur-panel) var(--ease-out)",
+      }}
+    >
+      <div className="overflow-hidden">
+        <div
+          className="bg-slate-800 border-b border-slate-700 px-6 py-3 flex items-center justify-between"
+          style={{
+            opacity: isCompact ? 0 : 1,
+            transform: isCompact ? "translateY(-100%)" : "translateY(0)",
+            transition: "opacity var(--dur-panel) var(--ease-out), transform var(--dur-panel) var(--ease-out)",
+          }}
+          inert={isCompact}
+        >
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                const next = !isDrawMode;
+                setIsDrawMode(next);
+                if (next) setIsCompact(false);
+              }}
+              className={cn(
+                "px-5 py-2.5 rounded-xl",
+                isDrawMode
+                  ? "bg-green-600 text-white shadow-lg hover:bg-green-700"
+                  : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+              )}
+            >
+              {isDrawMode ? (
+                <>
+                  <Pencil className="w-5 h-5" />
+                  그리기 모드
+                </>
+              ) : (
+                <>
+                  <Eye className="w-5 h-5" />
+                  보기 모드
+                </>
+              )}
+            </Button>
+
+            {isDrawMode && (
+              <>
+                <Popover open={toolPopoverOpen} onOpenChange={setToolPopoverOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="bg-slate-700 text-slate-300 hover:bg-slate-600 px-4 py-2.5 rounded-xl"
+                    >
+                      <Palette className="w-5 h-5" />
+                      <span className="text-sm">도구</span>
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-80 bg-slate-800 border-slate-700 p-4" align="start">
+                    <div className="space-y-4">
+                      {/* 색상 팔레트 */}
+                      <div>
+                        <div className="text-xs font-semibold text-slate-400 mb-2">색상</div>
+                        <div className="flex items-center gap-2">
+                          {penColors.map((pen) => (
+                            <button
+                              key={pen.value}
+                              onClick={() => {
+                                setSelectedColor(pen.value);
+                                setEraserType("none");
+                              }}
+                              className={`w-10 h-10 rounded-lg ${pen.color} transition-transform hover:scale-110 ${
+                                selectedColor === pen.value && eraserType === "none"
+                                  ? `ring-4 scale-110 ${pen.value === "#ffffff" ? "ring-blue-400" : "ring-white"}`
+                                  : ""
+                              }`}
+                            />
+                          ))}
+                        </div>
+                      </div>
+
+                      {/* 펜 굵기 */}
+                      <div>
+                        <div className="text-xs font-semibold text-slate-400 mb-2">펜 굵기</div>
+                        <div className="flex items-center gap-2 bg-slate-700 rounded-lg px-3 py-2 w-fit">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="p-1 h-auto w-auto hover:bg-slate-600 text-slate-300 rounded"
+                            onClick={() => setPenWidth((p) => Math.max(p - 1, 1))}
+                          >
+                            <Minus className="w-4 h-4" />
+                          </Button>
+                          <div className="text-slate-300 font-semibold min-w-7.5 text-center">{penWidth}</div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="p-1 h-auto w-auto hover:bg-slate-600 text-slate-300 rounded"
+                            onClick={() => setPenWidth((p) => Math.min(p + 1, 20))}
+                          >
+                            <PlusIcon className="w-4 h-4" />
+                          </Button>
+                        </div>
+                      </div>
+
+                      {/* 지우개 */}
+                      <div>
+                        <div className="text-xs font-semibold text-slate-400 mb-2">지우개</div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setEraserType((p) => (p === "area" ? "none" : "area"))}
+                            className={cn(
+                              "px-3 py-2.5 flex-1",
+                              eraserType === "area"
+                                ? "bg-orange-600 text-white hover:bg-orange-700"
+                                : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+                            )}
+                          >
+                            <Eraser className="w-5 h-5" />
+                            <span className="text-sm">영역</span>
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setEraserType((p) => (p === "stroke" ? "none" : "stroke"))}
+                            className={cn(
+                              "px-3 py-2.5 flex-1",
+                              eraserType === "stroke"
+                                ? "bg-red-600 text-white hover:bg-red-700"
+                                : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+                            )}
+                          >
+                            <Trash className="w-5 h-5" />
+                            <span className="text-sm">획</span>
+                          </Button>
+                        </div>
+                      </div>
+
+                      {/* 지우개 크기 (영역 선택 시) */}
+                      {eraserType === "area" && (
+                        <div>
+                          <div className="text-xs font-semibold text-slate-400 mb-2">지우개 크기</div>
+                          <div className="flex items-center gap-2 bg-orange-700 rounded-lg px-3 py-2 w-fit">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="p-1 h-auto w-auto hover:bg-orange-600 text-white rounded"
+                              onClick={() => setEraserWidth((p) => Math.max(p - 2, 5))}
+                            >
+                              <Minus className="w-4 h-4" />
+                            </Button>
+                            <div className="text-white font-semibold min-w-7.5 text-center">{eraserWidth}</div>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="p-1 h-auto w-auto hover:bg-orange-600 text-white rounded"
+                              onClick={() => setEraserWidth((p) => Math.min(p + 2, 50))}
+                            >
+                              <PlusIcon className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* 실행취소/다시실행 */}
+                      <div>
+                        <div className="text-xs font-semibold text-slate-400 mb-2">실행취소</div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="bg-slate-700 hover:bg-slate-600 text-slate-300 flex-1"
+                            onClick={() => undo()}
+                          >
+                            <Undo className="w-5 h-5" />
+                            <span className="text-sm">되돌리기</span>
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="bg-slate-700 hover:bg-slate-600 text-slate-300 flex-1"
+                            onClick={() => redo()}
+                          >
+                            <Redo className="w-5 h-5" />
+                            <span className="text-sm">다시실행</span>
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="bg-slate-700 hover:bg-slate-600 text-slate-300 p-2.5"
+                  onClick={() => undo()}
+                >
+                  <Undo className="w-5 h-5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="bg-slate-700 hover:bg-slate-600 text-slate-300 p-2.5"
+                  onClick={() => redo()}
+                >
+                  <Redo className="w-5 h-5" />
+                </Button>
+              </>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3">
+            {hasSheet && (
+              <Button
+                size="sm"
+                className="bg-amber-600 text-white hover:bg-amber-700 px-4 py-2.5 rounded-xl"
+                onClick={onSpotlightCall}
+                title="현재 페이지를 다른 사용자에게 호출"
+              >
+                <Megaphone className="w-5 h-5" />
+                <span className="text-sm">호출</span>
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onToggleCommandPanel}
+              className={cn(
+                "px-5 py-2.5 rounded-xl",
+                showCommandPanel
+                  ? "bg-purple-600 text-white shadow-lg hover:bg-purple-700"
+                  : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+              )}
+            >
+              명령 패널
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default memo(DrawingToolbar);

--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -76,7 +76,7 @@ function DrawingToolbar({
     >
       <div className="overflow-hidden">
         <div
-          className="bg-slate-800 border-b border-slate-700 px-6 py-3 flex items-center justify-between"
+          className="bg-viewer-panel border-b border-viewer-border px-6 py-3 flex items-center justify-between"
           style={{
             opacity: isCompact ? 0 : 1,
             transform: isCompact ? "translateY(-100%)" : "translateY(0)",
@@ -96,8 +96,8 @@ function DrawingToolbar({
               className={cn(
                 "px-5 py-2.5 rounded-xl",
                 isDrawMode
-                  ? "bg-green-600 text-white shadow-lg hover:bg-green-700"
-                  : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+                  ? "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
+                  : "bg-white/5 text-viewer-muted hover:bg-white/10",
               )}
             >
               {isDrawMode ? (
@@ -120,17 +120,17 @@ function DrawingToolbar({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="bg-slate-700 text-slate-300 hover:bg-slate-600 px-4 py-2.5 rounded-xl"
+                      className="bg-white/5 text-viewer-muted hover:bg-white/10 px-4 py-2.5 rounded-xl"
                     >
                       <Palette className="w-5 h-5" />
                       <span className="text-sm">도구</span>
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-80 bg-slate-800 border-slate-700 p-4" align="start">
+                  <PopoverContent className="w-80 bg-viewer-panel border-viewer-border p-4" align="start">
                     <div className="space-y-4">
                       {/* 색상 팔레트 */}
                       <div>
-                        <div className="text-xs font-semibold text-slate-400 mb-2">색상</div>
+                        <div className="text-xs font-semibold text-viewer-muted mb-2">색상</div>
                         <div className="flex items-center gap-2">
                           {penColors.map((pen) => (
                             <button
@@ -139,7 +139,7 @@ function DrawingToolbar({
                                 setSelectedColor(pen.value);
                                 setEraserType("none");
                               }}
-                              className={`w-10 h-10 rounded-lg ${pen.color} transition-transform hover:scale-110 ${
+                              className={`w-11 h-11 rounded-lg ${pen.color} transition-transform hover:scale-110 ${
                                 selectedColor === pen.value && eraserType === "none"
                                   ? `ring-4 scale-110 ${pen.value === "#ffffff" ? "ring-blue-400" : "ring-white"}`
                                   : ""
@@ -151,21 +151,21 @@ function DrawingToolbar({
 
                       {/* 펜 굵기 */}
                       <div>
-                        <div className="text-xs font-semibold text-slate-400 mb-2">펜 굵기</div>
-                        <div className="flex items-center gap-2 bg-slate-700 rounded-lg px-3 py-2 w-fit">
+                        <div className="text-xs font-semibold text-viewer-muted mb-2">펜 굵기</div>
+                        <div className="flex items-center gap-2 bg-white/5 rounded-lg px-3 py-2 w-fit">
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="p-1 h-auto w-auto hover:bg-slate-600 text-slate-300 rounded"
+                            className="min-h-11 min-w-11 hover:bg-white/10 text-viewer-muted rounded"
                             onClick={() => setPenWidth((p) => Math.max(p - 1, 1))}
                           >
                             <Minus className="w-4 h-4" />
                           </Button>
-                          <div className="text-slate-300 font-semibold min-w-7.5 text-center">{penWidth}</div>
+                          <div className="text-viewer-foreground font-semibold min-w-7.5 text-center">{penWidth}</div>
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="p-1 h-auto w-auto hover:bg-slate-600 text-slate-300 rounded"
+                            className="min-h-11 min-w-11 hover:bg-white/10 text-viewer-muted rounded"
                             onClick={() => setPenWidth((p) => Math.min(p + 1, 20))}
                           >
                             <PlusIcon className="w-4 h-4" />
@@ -175,7 +175,7 @@ function DrawingToolbar({
 
                       {/* 지우개 */}
                       <div>
-                        <div className="text-xs font-semibold text-slate-400 mb-2">지우개</div>
+                        <div className="text-xs font-semibold text-viewer-muted mb-2">지우개</div>
                         <div className="flex items-center gap-2">
                           <Button
                             variant="ghost"
@@ -184,8 +184,8 @@ function DrawingToolbar({
                             className={cn(
                               "px-3 py-2.5 flex-1",
                               eraserType === "area"
-                                ? "bg-orange-600 text-white hover:bg-orange-700"
-                                : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+                                ? "bg-white/15 text-viewer-foreground hover:bg-white/20"
+                                : "bg-white/5 text-viewer-muted hover:bg-white/10",
                             )}
                           >
                             <Eraser className="w-5 h-5" />
@@ -198,8 +198,8 @@ function DrawingToolbar({
                             className={cn(
                               "px-3 py-2.5 flex-1",
                               eraserType === "stroke"
-                                ? "bg-red-600 text-white hover:bg-red-700"
-                                : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+                                ? "bg-white/15 text-viewer-foreground hover:bg-white/20"
+                                : "bg-white/5 text-viewer-muted hover:bg-white/10",
                             )}
                           >
                             <Trash className="w-5 h-5" />
@@ -211,21 +211,23 @@ function DrawingToolbar({
                       {/* 지우개 크기 (영역 선택 시) */}
                       {eraserType === "area" && (
                         <div>
-                          <div className="text-xs font-semibold text-slate-400 mb-2">지우개 크기</div>
-                          <div className="flex items-center gap-2 bg-orange-700 rounded-lg px-3 py-2 w-fit">
+                          <div className="text-xs font-semibold text-viewer-muted mb-2">지우개 크기</div>
+                          <div className="flex items-center gap-2 bg-white/10 rounded-lg px-3 py-2 w-fit">
                             <Button
                               variant="ghost"
                               size="icon"
-                              className="p-1 h-auto w-auto hover:bg-orange-600 text-white rounded"
+                              className="min-h-11 min-w-11 hover:bg-white/15 text-viewer-foreground rounded"
                               onClick={() => setEraserWidth((p) => Math.max(p - 2, 5))}
                             >
                               <Minus className="w-4 h-4" />
                             </Button>
-                            <div className="text-white font-semibold min-w-7.5 text-center">{eraserWidth}</div>
+                            <div className="text-viewer-foreground font-semibold min-w-7.5 text-center">
+                              {eraserWidth}
+                            </div>
                             <Button
                               variant="ghost"
                               size="icon"
-                              className="p-1 h-auto w-auto hover:bg-orange-600 text-white rounded"
+                              className="min-h-11 min-w-11 hover:bg-white/15 text-viewer-foreground rounded"
                               onClick={() => setEraserWidth((p) => Math.min(p + 2, 50))}
                             >
                               <PlusIcon className="w-4 h-4" />
@@ -236,12 +238,12 @@ function DrawingToolbar({
 
                       {/* 실행취소/다시실행 */}
                       <div>
-                        <div className="text-xs font-semibold text-slate-400 mb-2">실행취소</div>
+                        <div className="text-xs font-semibold text-viewer-muted mb-2">실행취소</div>
                         <div className="flex items-center gap-2">
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="bg-slate-700 hover:bg-slate-600 text-slate-300 flex-1"
+                            className="bg-white/5 hover:bg-white/10 text-viewer-muted flex-1"
                             onClick={() => undo()}
                           >
                             <Undo className="w-5 h-5" />
@@ -250,7 +252,7 @@ function DrawingToolbar({
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="bg-slate-700 hover:bg-slate-600 text-slate-300 flex-1"
+                            className="bg-white/5 hover:bg-white/10 text-viewer-muted flex-1"
                             onClick={() => redo()}
                           >
                             <Redo className="w-5 h-5" />
@@ -265,7 +267,7 @@ function DrawingToolbar({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="bg-slate-700 hover:bg-slate-600 text-slate-300 p-2.5"
+                  className="bg-white/5 hover:bg-white/10 text-viewer-muted min-h-11 min-w-11"
                   onClick={() => undo()}
                 >
                   <Undo className="w-5 h-5" />
@@ -273,7 +275,7 @@ function DrawingToolbar({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="bg-slate-700 hover:bg-slate-600 text-slate-300 p-2.5"
+                  className="bg-white/5 hover:bg-white/10 text-viewer-muted min-h-11 min-w-11"
                   onClick={() => redo()}
                 >
                   <Redo className="w-5 h-5" />
@@ -301,8 +303,8 @@ function DrawingToolbar({
               className={cn(
                 "px-5 py-2.5 rounded-xl",
                 showCommandPanel
-                  ? "bg-purple-600 text-white shadow-lg hover:bg-purple-700"
-                  : "bg-slate-700 text-slate-300 hover:bg-slate-600",
+                  ? "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
+                  : "bg-white/5 text-viewer-muted hover:bg-white/10",
               )}
             >
               명령 패널

--- a/client/src/components/worship/PageNavigator.tsx
+++ b/client/src/components/worship/PageNavigator.tsx
@@ -1,0 +1,48 @@
+import { memo } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface PageNavigatorProps {
+  visible: boolean;
+  currentPage: number;
+  total: number;
+  onNavigate: (targetPage: number) => void;
+}
+
+// 악보 영역 하단의 페이지 이동 바 (3초 후 자동 숨김 — visible로 제어).
+function PageNavigator({ visible, currentPage, total, onNavigate }: PageNavigatorProps) {
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      className={cn(
+        "absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-4 bg-slate-800/70 backdrop-blur-sm rounded-2xl px-6 py-4 shadow-2xl transition-opacity duration-300",
+        visible ? "opacity-100" : "opacity-0 pointer-events-none",
+      )}
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className="bg-slate-700 hover:bg-slate-600 text-white"
+        onClick={() => onNavigate(currentPage - 1)}
+        disabled={currentPage <= 0}
+      >
+        <ChevronLeft className="w-6 h-6" />
+      </Button>
+      <span className="text-white font-semibold text-lg min-w-25 text-center">
+        {currentPage + 1} / {total}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="bg-slate-700 hover:bg-slate-600 text-white"
+        onClick={() => onNavigate(currentPage + 1)}
+        disabled={currentPage >= total - 1}
+      >
+        <ChevronRight className="w-6 h-6" />
+      </Button>
+    </div>
+  );
+}
+
+export default memo(PageNavigator);

--- a/client/src/components/worship/PageNavigator.tsx
+++ b/client/src/components/worship/PageNavigator.tsx
@@ -16,26 +16,26 @@ function PageNavigator({ visible, currentPage, total, onNavigate }: PageNavigato
     <div
       onClick={(e) => e.stopPropagation()}
       className={cn(
-        "absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-4 bg-slate-800/70 backdrop-blur-sm rounded-2xl px-6 py-4 shadow-2xl transition-opacity duration-300",
+        "absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-4 bg-viewer-panel/70 backdrop-blur-sm rounded-2xl px-6 py-4 shadow-2xl transition-opacity duration-300",
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
       )}
     >
       <Button
         variant="ghost"
         size="icon"
-        className="bg-slate-700 hover:bg-slate-600 text-white"
+        className="bg-white/5 hover:bg-white/10 text-viewer-foreground"
         onClick={() => onNavigate(currentPage - 1)}
         disabled={currentPage <= 0}
       >
         <ChevronLeft className="w-6 h-6" />
       </Button>
-      <span className="text-white font-semibold text-lg min-w-25 text-center">
+      <span className="text-viewer-foreground font-semibold text-lg min-w-25 text-center">
         {currentPage + 1} / {total}
       </span>
       <Button
         variant="ghost"
         size="icon"
-        className="bg-slate-700 hover:bg-slate-600 text-white"
+        className="bg-white/5 hover:bg-white/10 text-viewer-foreground"
         onClick={() => onNavigate(currentPage + 1)}
         disabled={currentPage >= total - 1}
       >

--- a/client/src/components/worship/SheetListSidebar.tsx
+++ b/client/src/components/worship/SheetListSidebar.tsx
@@ -1,0 +1,105 @@
+import { memo } from "react";
+import { Link } from "react-router";
+import { motion } from "motion/react";
+import { FileMusic, Edit } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import type { Sheet, PresenceUser } from "@/types";
+import { panelTransition, panelContentTransition } from "./panelMotion";
+
+interface SheetListSidebarProps {
+  show: boolean;
+  reducedMotion: boolean;
+  sheets: Sheet[];
+  currentSheetId: string | null;
+  presenceUsers: PresenceUser[];
+  worshipId: string | undefined;
+  onSelectPage: (index: number) => void;
+}
+
+// 좌측 악보 리스트 (슬라이드 인/아웃 + 접속자 표시).
+function SheetListSidebar({
+  show,
+  reducedMotion,
+  sheets,
+  currentSheetId,
+  presenceUsers,
+  worshipId,
+  onSelectPage,
+}: SheetListSidebarProps) {
+  return (
+    <motion.aside
+      aria-hidden={!show}
+      inert={!show}
+      initial={false}
+      animate={show ? { width: "16rem", opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: -12 }}
+      transition={reducedMotion ? { duration: 0 } : panelTransition}
+      className={cn("shrink-0 bg-slate-800 overflow-hidden", show && "border-r border-slate-700")}
+      style={{ pointerEvents: show ? "auto" : "none" }}
+    >
+      {/* 좌측은 첫 flex 항목이라 콘텐츠가 화면 끝에 고정됨 → 내부 독립 translate를
+          쓰면 프레임과 분리된 parallax로 보인다. opacity만 페이드하고 슬라이드는
+          aside의 x(-12→0)에 맡겨 패널 전체가 한 덩어리로 움직이게 한다.
+          (우측 패널은 콘텐츠가 움직이는 divider를 따라가 통합 슬라이드로 읽히므로 내부 x 유지) */}
+      <motion.div
+        animate={show ? { opacity: 1 } : { opacity: 0 }}
+        transition={reducedMotion ? { duration: 0 } : panelContentTransition}
+        className="w-64 h-full overflow-y-auto p-4 box-border"
+      >
+        <h2 className="text-lg font-bold text-white mb-4">악보 목록</h2>
+
+        {sheets.length > 0 ? (
+          <div className="space-y-2">
+            {sheets.map((sheet, index) => {
+              const usersOnSheet = presenceUsers.filter((u) => u.sheetId === sheet.id);
+              return (
+                <button
+                  key={sheet.id}
+                  onClick={() => onSelectPage(index)}
+                  className={`w-full text-left p-4 rounded-xl cursor-pointer transition-colors ${
+                    currentSheetId === sheet.id
+                      ? "bg-blue-600 text-white shadow-lg"
+                      : "bg-slate-700 text-slate-300 hover:bg-slate-600"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <FileMusic className="w-5 h-5" />
+                    <div className="flex-1 min-w-0">
+                      <div className="font-semibold mb-1 line-clamp-2">{sheet.title}</div>
+                      <div className="text-sm opacity-75">페이지 {index + 1}</div>
+                    </div>
+                    {usersOnSheet.length > 0 && (
+                      <div className="flex -space-x-1">
+                        {usersOnSheet.slice(0, 3).map((u) => (
+                          <span key={u.profileId} className="text-sm" title={`${u.name} (${u.role})`}>
+                            {u.roleIcon}
+                          </span>
+                        ))}
+                        {usersOnSheet.length > 3 && (
+                          <span className="text-xs text-slate-400 ml-1">+{usersOnSheet.length - 3}</span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-12 bg-slate-700 rounded-xl">
+            <FileMusic className="w-12 h-12 text-slate-500 mx-auto mb-3" />
+            <p className="text-slate-400 text-sm mb-4">악보가 없습니다</p>
+            <Button size="sm" className="bg-blue-600 hover:bg-blue-700" asChild>
+              <Link to={`/worship-edit/${worshipId}`}>
+                <Edit className="w-4 h-4" />
+                편집 페이지에서 추가
+              </Link>
+            </Button>
+          </div>
+        )}
+      </motion.div>
+    </motion.aside>
+  );
+}
+
+export default memo(SheetListSidebar);

--- a/client/src/components/worship/SheetListSidebar.tsx
+++ b/client/src/components/worship/SheetListSidebar.tsx
@@ -34,7 +34,7 @@ function SheetListSidebar({
       initial={false}
       animate={show ? { width: "16rem", opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: -12 }}
       transition={reducedMotion ? { duration: 0 } : panelTransition}
-      className={cn("shrink-0 bg-slate-800 overflow-hidden", show && "border-r border-slate-700")}
+      className={cn("shrink-0 bg-viewer-panel overflow-hidden", show && "border-r border-viewer-border")}
       style={{ pointerEvents: show ? "auto" : "none" }}
     >
       {/* 좌측은 첫 flex 항목이라 콘텐츠가 화면 끝에 고정됨 → 내부 독립 translate를
@@ -46,7 +46,7 @@ function SheetListSidebar({
         transition={reducedMotion ? { duration: 0 } : panelContentTransition}
         className="w-64 h-full overflow-y-auto p-4 box-border"
       >
-        <h2 className="text-lg font-bold text-white mb-4">악보 목록</h2>
+        <h2 className="text-lg font-bold text-viewer-foreground mb-4">악보 목록</h2>
 
         {sheets.length > 0 ? (
           <div className="space-y-2">
@@ -58,8 +58,8 @@ function SheetListSidebar({
                   onClick={() => onSelectPage(index)}
                   className={`w-full text-left p-4 rounded-xl cursor-pointer transition-colors ${
                     currentSheetId === sheet.id
-                      ? "bg-blue-600 text-white shadow-lg"
-                      : "bg-slate-700 text-slate-300 hover:bg-slate-600"
+                      ? "bg-primary text-primary-foreground shadow-sm"
+                      : "bg-white/5 text-viewer-muted hover:bg-white/10"
                   }`}
                 >
                   <div className="flex items-center gap-3">
@@ -76,7 +76,7 @@ function SheetListSidebar({
                           </span>
                         ))}
                         {usersOnSheet.length > 3 && (
-                          <span className="text-xs text-slate-400 ml-1">+{usersOnSheet.length - 3}</span>
+                          <span className="text-xs text-viewer-muted ml-1">+{usersOnSheet.length - 3}</span>
                         )}
                       </div>
                     )}
@@ -86,10 +86,10 @@ function SheetListSidebar({
             })}
           </div>
         ) : (
-          <div className="text-center py-12 bg-slate-700 rounded-xl">
-            <FileMusic className="w-12 h-12 text-slate-500 mx-auto mb-3" />
-            <p className="text-slate-400 text-sm mb-4">악보가 없습니다</p>
-            <Button size="sm" className="bg-blue-600 hover:bg-blue-700" asChild>
+          <div className="text-center py-12 bg-white/5 rounded-xl">
+            <FileMusic className="w-12 h-12 text-viewer-muted mx-auto mb-3" />
+            <p className="text-viewer-muted text-sm mb-4">악보가 없습니다</p>
+            <Button size="sm" asChild>
               <Link to={`/worship-edit/${worshipId}`}>
                 <Edit className="w-4 h-4" />
                 편집 페이지에서 추가

--- a/client/src/components/worship/SpotlightToast.tsx
+++ b/client/src/components/worship/SpotlightToast.tsx
@@ -1,0 +1,21 @@
+interface SpotlightToastProps {
+  senderName: string;
+  sheetTitle: string;
+  onAccept: () => void;
+}
+
+// page:spotlight 수신 시 표시하는 호출 토스트 카드 (탭하면 해당 페이지로 이동 + 닫힘).
+export default function SpotlightToast({ senderName, sheetTitle, onAccept }: SpotlightToastProps) {
+  return (
+    <div
+      className="bg-white rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-amber-500 cursor-pointer active:bg-amber-50 transition-colors"
+      onClick={onAccept}
+    >
+      <div className="text-4xl">📢</div>
+      <div className="flex-1">
+        <div className="text-lg font-bold text-slate-800">{senderName}님이 호출합니다</div>
+        <div className="text-sm text-slate-500 mt-1">&quot;{sheetTitle}&quot;로 이동하려면 클릭하세요</div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/worship/SpotlightToast.tsx
+++ b/client/src/components/worship/SpotlightToast.tsx
@@ -8,13 +8,13 @@ interface SpotlightToastProps {
 export default function SpotlightToast({ senderName, sheetTitle, onAccept }: SpotlightToastProps) {
   return (
     <div
-      className="bg-white rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-amber-500 cursor-pointer active:bg-amber-50 transition-colors"
+      className="bg-card rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-amber-500 cursor-pointer active:bg-amber-50 transition-colors"
       onClick={onAccept}
     >
       <div className="text-4xl">📢</div>
       <div className="flex-1">
-        <div className="text-lg font-bold text-slate-800">{senderName}님이 호출합니다</div>
-        <div className="text-sm text-slate-500 mt-1">&quot;{sheetTitle}&quot;로 이동하려면 클릭하세요</div>
+        <div className="text-lg font-bold text-foreground">{senderName}님이 호출합니다</div>
+        <div className="text-sm text-muted-foreground mt-1">&quot;{sheetTitle}&quot;로 이동하려면 클릭하세요</div>
       </div>
     </div>
   );

--- a/client/src/components/worship/WorshipHeader.tsx
+++ b/client/src/components/worship/WorshipHeader.tsx
@@ -37,7 +37,7 @@ function WorshipHeader({
     >
       <div className="overflow-hidden">
         <header
-          className="bg-slate-800 border-b border-slate-700 px-6 py-4 flex items-center justify-between"
+          className="bg-viewer-panel border-b border-viewer-border px-6 py-4 flex items-center justify-between"
           style={{
             opacity: isCompact ? 0 : 1,
             transform: isCompact ? "translateY(-100%)" : "translateY(0)",
@@ -46,16 +46,21 @@ function WorshipHeader({
           inert={isCompact}
         >
           <div className="flex items-center gap-4">
-            <Button variant="ghost" size="icon" className="hover:bg-slate-700 text-slate-300" asChild>
+            <Button variant="ghost" size="icon" className="hover:bg-white/10 text-viewer-muted" asChild>
               <Link to="/worship-list">
                 <ArrowLeft className="w-6 h-6" />
               </Link>
             </Button>
-            <Button variant="ghost" size="icon" className="hover:bg-slate-700 text-slate-300" onClick={onToggleSidebar}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hover:bg-white/10 text-viewer-muted"
+              onClick={onToggleSidebar}
+            >
               <Menu className="w-6 h-6" />
             </Button>
-            <div className="h-8 w-px bg-slate-600" />
-            <h1 className="text-xl font-bold text-white">{worshipTitle || "예배"}</h1>
+            <div className="h-8 w-px bg-viewer-border" />
+            <h1 className="text-xl font-bold text-viewer-foreground">{worshipTitle || "예배"}</h1>
           </div>
 
           <div className="flex items-center gap-3">
@@ -66,7 +71,7 @@ function WorshipHeader({
                 <span className="text-xs font-medium text-red-400">연결 끊김</span>
               </div>
             )}
-            <Button variant="ghost" size="sm" className="bg-slate-700 text-slate-300 hover:bg-slate-600" asChild>
+            <Button variant="ghost" size="sm" className="bg-white/5 text-viewer-muted hover:bg-white/10" asChild>
               <Link to={`/worship-edit/${worshipId}`}>
                 <Edit className="w-5 h-5" />
                 <span>편집</span>
@@ -78,23 +83,23 @@ function WorshipHeader({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="bg-slate-700 text-slate-300 hover:bg-slate-600 cursor-pointer"
+                  className="bg-white/5 text-viewer-muted hover:bg-white/10 cursor-pointer"
                 >
                   <Users className="w-5 h-5" />
                   <span>{presenceUsers.length}명 접속</span>
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-64 bg-slate-800 border-slate-700 p-0" align="end">
-                <div className="p-3 border-b border-slate-700">
-                  <h3 className="text-sm font-semibold text-white">접속 중인 사용자</h3>
+              <PopoverContent className="w-64 bg-viewer-panel border-viewer-border p-0" align="end">
+                <div className="p-3 border-b border-viewer-border">
+                  <h3 className="text-sm font-semibold text-viewer-foreground">접속 중인 사용자</h3>
                 </div>
                 <div className="p-2 max-h-60 overflow-y-auto">
                   {presenceUsers.map((user) => (
                     <div key={user.profileId} className="flex items-center gap-3 px-2 py-2 rounded-lg">
                       <span className="text-lg">{user.roleIcon}</span>
                       <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium text-white truncate">{user.name}</div>
-                        <div className="text-xs text-slate-400">{user.role}</div>
+                        <div className="text-sm font-medium text-viewer-foreground truncate">{user.name}</div>
+                        <div className="text-xs text-viewer-muted">{user.role}</div>
                       </div>
                     </div>
                   ))}

--- a/client/src/components/worship/WorshipHeader.tsx
+++ b/client/src/components/worship/WorshipHeader.tsx
@@ -1,0 +1,111 @@
+import { memo } from "react";
+import { Link } from "react-router";
+import { ArrowLeft, Menu, Edit, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { PresenceUser } from "@/types";
+
+interface WorshipHeaderProps {
+  worshipTitle: string | undefined;
+  worshipId: string | undefined;
+  isCompact: boolean;
+  isConnected: boolean;
+  presenceUsers: PresenceUser[];
+  presencePopoverOpen: boolean;
+  onPresencePopoverChange: (open: boolean) => void;
+  onToggleSidebar: () => void;
+}
+
+// 상단 헤더 (컴팩트 시 세로 콜랩스 + 페이드 — 찌그러짐 없는 push).
+function WorshipHeader({
+  worshipTitle,
+  worshipId,
+  isCompact,
+  isConnected,
+  presenceUsers,
+  presencePopoverOpen,
+  onPresencePopoverChange,
+  onToggleSidebar,
+}: WorshipHeaderProps) {
+  return (
+    <div
+      className="grid"
+      style={{
+        gridTemplateRows: isCompact ? "0fr" : "1fr",
+        transition: "grid-template-rows var(--dur-panel) var(--ease-out)",
+      }}
+    >
+      <div className="overflow-hidden">
+        <header
+          className="bg-slate-800 border-b border-slate-700 px-6 py-4 flex items-center justify-between"
+          style={{
+            opacity: isCompact ? 0 : 1,
+            transform: isCompact ? "translateY(-100%)" : "translateY(0)",
+            transition: "opacity var(--dur-panel) var(--ease-out), transform var(--dur-panel) var(--ease-out)",
+          }}
+          inert={isCompact}
+        >
+          <div className="flex items-center gap-4">
+            <Button variant="ghost" size="icon" className="hover:bg-slate-700 text-slate-300" asChild>
+              <Link to="/worship-list">
+                <ArrowLeft className="w-6 h-6" />
+              </Link>
+            </Button>
+            <Button variant="ghost" size="icon" className="hover:bg-slate-700 text-slate-300" onClick={onToggleSidebar}>
+              <Menu className="w-6 h-6" />
+            </Button>
+            <div className="h-8 w-px bg-slate-600" />
+            <h1 className="text-xl font-bold text-white">{worshipTitle || "예배"}</h1>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {/* 서버 연결 상태 인디케이터 */}
+            {!isConnected && (
+              <div className="flex items-center gap-2 px-3 py-1.5 bg-red-600/20 border border-red-500/30 rounded-lg">
+                <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                <span className="text-xs font-medium text-red-400">연결 끊김</span>
+              </div>
+            )}
+            <Button variant="ghost" size="sm" className="bg-slate-700 text-slate-300 hover:bg-slate-600" asChild>
+              <Link to={`/worship-edit/${worshipId}`}>
+                <Edit className="w-5 h-5" />
+                <span>편집</span>
+              </Link>
+            </Button>
+            {/* 컴팩트 시 헤더가 접히면 포털된 PopoverContent도 함께 닫음(inert는 포털 밖을 못 막음) */}
+            <Popover open={presencePopoverOpen && !isCompact} onOpenChange={onPresencePopoverChange}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="bg-slate-700 text-slate-300 hover:bg-slate-600 cursor-pointer"
+                >
+                  <Users className="w-5 h-5" />
+                  <span>{presenceUsers.length}명 접속</span>
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-64 bg-slate-800 border-slate-700 p-0" align="end">
+                <div className="p-3 border-b border-slate-700">
+                  <h3 className="text-sm font-semibold text-white">접속 중인 사용자</h3>
+                </div>
+                <div className="p-2 max-h-60 overflow-y-auto">
+                  {presenceUsers.map((user) => (
+                    <div key={user.profileId} className="flex items-center gap-3 px-2 py-2 rounded-lg">
+                      <span className="text-lg">{user.roleIcon}</span>
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-white truncate">{user.name}</div>
+                        <div className="text-xs text-slate-400">{user.role}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+        </header>
+      </div>
+    </div>
+  );
+}
+
+export default memo(WorshipHeader);

--- a/client/src/components/worship/panelMotion.ts
+++ b/client/src/components/worship/panelMotion.ts
@@ -1,0 +1,4 @@
+// 좌/우 패널 슬라이드 애니메이션 토큰 — 사이드바·명령패널이 동일한 모션을 공유한다.
+export const PANEL_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+export const panelTransition = { duration: 0.22, ease: PANEL_EASE };
+export const panelContentTransition = { duration: 0.16, ease: PANEL_EASE };

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -5,39 +5,49 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: #fafafa;
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --radius: 0.625rem;
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* 길튼 브랜드 팔레트 — 로고(로고 원본.png)에서 추출한 코발트 네이비/하늘색을
+     파스텔 톤으로 확장. 모든 색은 토큰을 거치게 하여 테마를 한 곳에서 관리한다. */
+  --background: #eff3f8;
+  --foreground: #15293b;
+  --card: #ffffff;
+  --card-foreground: #15293b;
+  --popover: #ffffff;
+  --popover-foreground: #15293b;
+  --primary: #005090; /* 로고 코발트 네이비 — 단일 브랜드 액션색 */
+  --primary-foreground: #f4f9fd;
+  --secondary: #e7ecf1;
+  --secondary-foreground: #3e5163;
+  --muted: #eaeef3;
+  --muted-foreground: #586775;
+  --accent: #e2eaf3; /* 하늘색 소프트 틴트 */
+  --accent-foreground: #1e4e7e;
+  --destructive: #9a342b;
+  --destructive-foreground: #ffffff;
+  --border: #e1e8ef;
+  --input: #e1e8ef;
+  --ring: #2e6fa8; /* 로고 블루 계열 — 포커스 링 (AA 대비 확보) */
+  --radius: 0.875rem; /* 14px — 친근하되 과하지 않게 */
+  --chart-1: #005090;
+  --chart-2: #70a0c8;
+  --chart-3: #5e9aa0;
+  --chart-4: #7e8ac0;
+  --chart-5: #8a9aa8;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #15293b;
+  --sidebar-primary: #005090;
+  --sidebar-primary-foreground: #f4f9fd;
+  --sidebar-accent: #e2eaf3;
+  --sidebar-accent-foreground: #1e4e7e;
+  --sidebar-border: #e1e8ef;
+  --sidebar-ring: #70a0c8;
+
+  /* 예배 뷰어 "무대" 크롬 — 앱 테마와 무관하게 항상 어두운 네이비.
+     로고 잉크 네이비에서 파생. 차가운 slate 대신 따뜻한 깊은 네이비. */
+  --viewer-bg: #16222e;
+  --viewer-panel: #1e2e3d;
+  --viewer-border: #2a3b4c;
+  --viewer-foreground: #e6edf3;
+  --viewer-muted: #aab8c6;
 
   /* 모션 토큰 — 헤더/툴바 콜랩스 CSS 트랜지션용 (좌우 패널은 motion/react 상수 사용) */
   --ease-out: cubic-bezier(0.33, 1, 0.68, 1); /* 깔끔한 감속(오버슈트 없음) */
@@ -64,6 +74,11 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-viewer-bg: var(--viewer-bg);
+  --color-viewer-panel: var(--viewer-panel);
+  --color-viewer-border: var(--viewer-border);
+  --color-viewer-foreground: var(--viewer-foreground);
+  --color-viewer-muted: var(--viewer-muted);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -99,7 +114,14 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family:
+      "Pretendard Variable",
+      "Pretendard",
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      Roboto,
+      sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     overscroll-behavior: none;

--- a/client/src/hooks/queries/useWorships.ts
+++ b/client/src/hooks/queries/useWorships.ts
@@ -1,16 +1,46 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "@/lib/axios";
 import { queryKeys } from "@/lib/queryKeys";
-import type { Worship, Sheet } from "@/types";
+import type { Worship, Sheet, WorshipPage } from "@/types";
 
 // --- Queries ---
 
-export function useWorships() {
+export interface WorshipListFilters {
+  typeId?: string;
+  q?: string;
+  year?: string;
+  month?: string;
+  limit?: number;
+}
+
+// 무한 스크롤 목록 — 서버 페이지네이션. 필터는 queryKey에 포함되어 변경 시 자동 재조회
+export function useWorships(filters: WorshipListFilters = {}) {
+  const { typeId = "", q = "", year = "", month = "", limit = 20 } = filters;
+  return useInfiniteQuery({
+    queryKey: queryKeys.worships.list({ typeId, q, year, month, limit }),
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams();
+      params.set("page", String(pageParam));
+      params.set("limit", String(limit));
+      if (typeId) params.set("typeId", typeId);
+      if (q) params.set("q", q);
+      if (year) params.set("year", year);
+      if (month) params.set("month", month);
+      const { data } = await api.get<WorshipPage>(`/api/worships?${params.toString()}`);
+      return data;
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage ?? undefined,
+  });
+}
+
+// 연도 목록 (필터 드롭다운용)
+export function useWorshipYears() {
   return useQuery({
-    queryKey: queryKeys.worships.all,
+    queryKey: queryKeys.worships.years,
     queryFn: async () => {
-      const { data } = await api.get<Worship[]>("/api/worships");
+      const { data } = await api.get<number[]>("/api/worships/years");
       return data;
     },
   });

--- a/client/src/hooks/useSheetZoomPan.ts
+++ b/client/src/hooks/useSheetZoomPan.ts
@@ -1,0 +1,174 @@
+import { useCallback, useRef, useState } from "react";
+
+interface UseSheetZoomPanOptions {
+  // 핀치 중심점/보정 계산 기준이 되는 악보 카드 div
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  // 1-finger 패닝 게이트 (그리기 모드에서는 패닝 안 함)
+  isDrawModeRef: React.RefObject<boolean>;
+  // 핀치 시작 시 진행 중인 페이지 드래그/애니메이션을 즉시 취소 (pinch 우선)
+  cancelPageMotionRef: React.RefObject<() => void>;
+}
+
+function parseOriginPercent(origin: string): [number, number] {
+  if (origin === "center center") return [50, 50];
+  const parts = origin.split(/\s+/);
+  return [parseFloat(parts[0]), parseFloat(parts[1])];
+}
+
+function getTouchDistance(touches: React.TouchList) {
+  const dx = touches[0].clientX - touches[1].clientX;
+  const dy = touches[0].clientY - touches[1].clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function getTouchCenter(touches: React.TouchList) {
+  return {
+    x: (touches[0].clientX + touches[1].clientX) / 2,
+    y: (touches[0].clientY + touches[1].clientY) / 2,
+  };
+}
+
+// 악보 카드의 핀치줌(2-finger) / 패닝(1-finger, zoom>1) / 더블탭 리셋 제스처.
+// CSS transform: scale()을 카드 컨테이너에 적용 — canvas 내부 좌표계는 rect 기반으로 자동 보정된다(client/CLAUDE.md).
+export function useSheetZoomPan({ containerRef, isDrawModeRef, cancelPageMotionRef }: UseSheetZoomPanOptions) {
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const [transformOrigin, setTransformOrigin] = useState("center center");
+  const scaleRef = useRef(1);
+  scaleRef.current = scale;
+  const pinchRef = useRef<{
+    startDist: number;
+    startScale: number;
+    startCenter: { x: number; y: number };
+    startTranslate: { x: number; y: number };
+  } | null>(null);
+  const panRef = useRef<{
+    startX: number;
+    startY: number;
+    startTranslate: { x: number; y: number };
+  } | null>(null);
+  const lastTapRef = useRef(0);
+
+  const resetZoom = useCallback(() => {
+    setScale(1);
+    setTranslate({ x: 0, y: 0 });
+    setTransformOrigin("center center");
+  }, []);
+
+  // 페이지 모션 차단 게이트 — useSheetPageMotion의 isBlocked가 호출한다.
+  const isZoomActive = useCallback(() => scaleRef.current > 1 || !!pinchRef.current || !!panRef.current, []);
+
+  const handleSheetTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (e.touches.length === 2) {
+        // 진행 중인 page drag/animation 즉시 취소 (pinch 우선)
+        cancelPageMotionRef.current();
+        // 핀치 시작
+        const dist = getTouchDistance(e.touches);
+        const center = getTouchCenter(e.touches);
+        panRef.current = null;
+
+        // 핀치 중심점을 transformOrigin으로 설정
+        // scale > 1이면 origin 변경에 따른 translate 보정으로 위치 점프 방지
+        let currentTranslate = { ...translate };
+        const container = containerRef.current;
+        if (container) {
+          const rect = container.getBoundingClientRect();
+          const newRelX = ((center.x - rect.left) / rect.width) * 100;
+          const newRelY = ((center.y - rect.top) / rect.height) * 100;
+
+          if (scaleRef.current > 1) {
+            const [oldRelX, oldRelY] = parseOriginPercent(transformOrigin);
+            const s = scaleRef.current;
+            // rect는 렌더링 크기(CSS너비×scale)이므로 /s로 CSS 원본 너비 복원
+            const cssWidth = rect.width / s;
+            const cssHeight = rect.height / s;
+            currentTranslate = {
+              x: translate.x + ((oldRelX - newRelX) / 100) * cssWidth * (1 - s),
+              y: translate.y + ((oldRelY - newRelY) / 100) * cssHeight * (1 - s),
+            };
+            setTranslate(currentTranslate);
+          }
+
+          setTransformOrigin(`${newRelX}% ${newRelY}%`);
+        }
+
+        pinchRef.current = {
+          startDist: dist,
+          startScale: scaleRef.current,
+          startCenter: center,
+          startTranslate: currentTranslate,
+        };
+
+        e.preventDefault();
+      } else if (e.touches.length === 1) {
+        // 더블탭 감지
+        const now = Date.now();
+        if (now - lastTapRef.current < 300) {
+          resetZoom();
+          e.preventDefault();
+          lastTapRef.current = 0;
+          return;
+        }
+        lastTapRef.current = now;
+
+        // zoom > 1 + 보기모드 → 패닝 시작
+        if (scaleRef.current > 1 && !isDrawModeRef.current) {
+          panRef.current = {
+            startX: e.touches[0].clientX,
+            startY: e.touches[0].clientY,
+            startTranslate: { ...translate },
+          };
+        }
+      }
+    },
+    [translate, transformOrigin, cancelPageMotionRef, containerRef, isDrawModeRef, resetZoom],
+  );
+
+  const handleSheetTouchMove = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length === 2 && pinchRef.current) {
+      const dist = getTouchDistance(e.touches);
+      const center = getTouchCenter(e.touches);
+      const newScale = Math.min(3, Math.max(1, pinchRef.current.startScale * (dist / pinchRef.current.startDist)));
+      const dx = center.x - pinchRef.current.startCenter.x;
+      const dy = center.y - pinchRef.current.startCenter.y;
+
+      if (newScale <= 1) {
+        setScale(1);
+        setTranslate({ x: 0, y: 0 });
+      } else {
+        setScale(newScale);
+        setTranslate({
+          x: pinchRef.current.startTranslate.x + dx,
+          y: pinchRef.current.startTranslate.y + dy,
+        });
+      }
+      e.preventDefault();
+    } else if (e.touches.length === 1 && panRef.current && scaleRef.current > 1) {
+      // 1-finger 패닝 (zoom > 1, 보기모드)
+      const dx = e.touches[0].clientX - panRef.current.startX;
+      const dy = e.touches[0].clientY - panRef.current.startY;
+      setTranslate({
+        x: panRef.current.startTranslate.x + dx,
+        y: panRef.current.startTranslate.y + dy,
+      });
+      e.preventDefault();
+    }
+  }, []);
+
+  const handleSheetTouchEnd = useCallback(() => {
+    pinchRef.current = null;
+    panRef.current = null;
+  }, []);
+
+  return {
+    scale,
+    translate,
+    transformOrigin,
+    handleSheetTouchStart,
+    handleSheetTouchMove,
+    handleSheetTouchEnd,
+    isZoomActive,
+    resetZoom,
+  };
+}

--- a/client/src/hooks/useWorshipPresence.tsx
+++ b/client/src/hooks/useWorshipPresence.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { getSocket } from "./useSocket";
+import type { PresenceUser } from "@/types";
+import CommandToast from "@/components/worship/CommandToast";
+import SpotlightToast from "@/components/worship/SpotlightToast";
+
+interface UseWorshipPresenceOptions {
+  worshipId: string | undefined;
+  onSpotlightAccept: (sheetId: string) => void;
+}
+
+// 접속자 현황(presence) + 명령(command) / 호출(spotlight) 토스트 수신.
+export function useWorshipPresence({ worshipId, onSpotlightAccept }: UseWorshipPresenceOptions) {
+  const socket = getSocket();
+  const [presenceUsers, setPresenceUsers] = useState<PresenceUser[]>([]);
+
+  // spotlight accept 콜백을 ref로 우회 — effect deps는 [worshipId, socket]이므로
+  // 콜백(commitSheetId)이 매 렌더 새로 만들어져도 재구독 없이 항상 최신 값을 호출.
+  const onSpotlightAcceptRef = useRef(onSpotlightAccept);
+  onSpotlightAcceptRef.current = onSpotlightAccept;
+
+  useEffect(() => {
+    const handlePresence = (data: { worshipId: string; users: PresenceUser[] }) => {
+      if (data.worshipId === worshipId) {
+        // 중복 프로필 제거
+        const seen = new Set<string>();
+        const unique = data.users.filter((u) => {
+          if (seen.has(u.profileId)) return false;
+          seen.add(u.profileId);
+          return true;
+        });
+        setPresenceUsers(unique);
+      }
+    };
+
+    const handleCommand = (data: {
+      commandId: string;
+      emoji: string;
+      label: string;
+      senderName: string;
+      senderRole: string;
+      senderRoleIcon: string;
+    }) => {
+      const toastId = `command-${Date.now()}`;
+      toast.custom(
+        () => (
+          <CommandToast
+            emoji={data.emoji}
+            label={data.label}
+            senderName={data.senderName}
+            senderRoleIcon={data.senderRoleIcon}
+            onDismiss={() => toast.dismiss(toastId)}
+          />
+        ),
+        { duration: 3000, position: "top-center", id: toastId },
+      );
+    };
+
+    const handleSpotlight = (data: { sheetId: string; sheetTitle: string; senderName: string; senderRole: string }) => {
+      const toastId = `spotlight-${Date.now()}`;
+      toast.custom(
+        () => (
+          <SpotlightToast
+            senderName={data.senderName}
+            sheetTitle={data.sheetTitle}
+            onAccept={() => {
+              onSpotlightAcceptRef.current(data.sheetId);
+              toast.dismiss(toastId);
+            }}
+          />
+        ),
+        { duration: 10000, position: "top-center", id: toastId },
+      );
+    };
+
+    socket.on("presence:update", handlePresence);
+    socket.on("command:received", handleCommand);
+    socket.on("page:spotlight", handleSpotlight);
+
+    return () => {
+      socket.off("presence:update", handlePresence);
+      socket.off("command:received", handleCommand);
+      socket.off("page:spotlight", handleSpotlight);
+    };
+  }, [worshipId, socket]);
+
+  return { presenceUsers };
+}

--- a/client/src/hooks/useWorshipRoom.ts
+++ b/client/src/hooks/useWorshipRoom.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { getSocket, setWorshipRoom } from "./useSocket";
+
+interface UseWorshipRoomOptions {
+  worshipId: string | undefined;
+  profileId: string | null;
+  currentSheetId: string | null;
+}
+
+// 예배 room 입장/퇴장 + 연결 상태 추적 + 현재 페이지 변경 알림.
+// 싱글톤 소켓(useSocket)을 사용 — 재연결 시 room 자동 재입장 로직이 싱글톤에 묶여 있다.
+export function useWorshipRoom({ worshipId, profileId, currentSheetId }: UseWorshipRoomOptions) {
+  const socket = getSocket();
+
+  // 예배 입장/퇴장
+  useEffect(() => {
+    if (!worshipId || !profileId) return;
+
+    socket.emit("join:worship", { worshipId, profileId });
+    setWorshipRoom({ worshipId, profileId });
+
+    return () => {
+      socket.emit("leave:worship", { worshipId });
+      setWorshipRoom(null);
+    };
+  }, [worshipId, profileId, socket]);
+
+  // 연결 상태 추적
+  const [isConnected, setIsConnected] = useState(socket.connected);
+  useEffect(() => {
+    const onDisconnect = () => setIsConnected(false);
+    const onConnect = () => setIsConnected(true);
+    socket.on("disconnect", onDisconnect);
+    socket.on("connect", onConnect);
+    return () => {
+      socket.off("disconnect", onDisconnect);
+      socket.off("connect", onConnect);
+    };
+  }, [socket]);
+
+  // 페이지 변경 알림
+  useEffect(() => {
+    if (!worshipId || !currentSheetId) return;
+    socket.emit("page:change", { worshipId, sheetId: currentSheetId });
+  }, [worshipId, currentSheetId, socket]);
+
+  return { isConnected };
+}

--- a/client/src/lib/canvas.ts
+++ b/client/src/lib/canvas.ts
@@ -1,0 +1,88 @@
+import type { Point } from "@/hooks/useDrawingSync";
+
+// 그리기/정규화의 단일 좌표계 기준이 되는 CSS-space content rect.
+// canvas backing store(DPR배 픽셀)가 아니라 레이아웃 크기(offsetWidth/Height) 기준으로만 계산해야
+// 좌표·굵기가 일치한다 — 자세한 불변식은 client/CLAUDE.md 참고.
+export interface ContentRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const FALLBACK_SHEET_ASPECT = 3 / 4;
+export const EMPTY_RECT: ContentRect = { x: 0, y: 0, width: 0, height: 0 };
+
+// 정규화 좌표 → 화면 좌표
+export function denormalizePoint(p: Point, rect: ContentRect): { x: number; y: number } {
+  return { x: rect.x + p.x * rect.width, y: rect.y + p.y * rect.height };
+}
+
+// 화면 좌표 → 정규화 좌표
+export function normalizePoint(x: number, y: number, rect: ContentRect): Point {
+  return { x: (x - rect.x) / rect.width, y: (y - rect.y) / rect.height };
+}
+
+export function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function getContainedRect(containerWidth: number, containerHeight: number, aspect: number): ContentRect {
+  if (containerWidth <= 0 || containerHeight <= 0 || aspect <= 0) return EMPTY_RECT;
+
+  const containerAspect = containerWidth / containerHeight;
+  if (containerAspect > aspect) {
+    const width = containerHeight * aspect;
+    return { x: (containerWidth - width) / 2, y: 0, width, height: containerHeight };
+  }
+
+  const height = containerWidth / aspect;
+  return { x: 0, y: (containerHeight - height) / 2, width: containerWidth, height };
+}
+
+// 그리기/정규화의 기준이 되는 CSS-space content rect. 좌표·굵기 계산은 모두 CSS px 기준이어야 하므로
+// backing store 픽셀(canvas.width, DPR배)이 아닌 레이아웃 크기(offsetWidth/Height)를 단일 기준으로 고정한다.
+// 한 call site라도 canvas.width로 되돌아가면 DPR배 오차가 나므로 helper로 묶어 불변식을 강제한다.
+export function getCanvasContentRect(canvas: HTMLCanvasElement, imageAspect: number | null): ContentRect {
+  return getContainedRect(canvas.offsetWidth, canvas.offsetHeight, imageAspect ?? FALLBACK_SHEET_ASPECT);
+}
+
+// backing store를 CSS 레이아웃 크기 × DPR로 동기화 (실제로 다를 때만 — 재설정 시 canvas가 클리어됨).
+// 사용한 dpr을 반환 — 호출부가 ctx.setTransform(dpr,…)로 좌표계를 CSS px로 통일한다.
+// ResizeObserver 경로와 redraw 경로가 같은 계산을 쓰도록 한곳에 모은다.
+export function syncCanvasBackingStore(canvas: HTMLCanvasElement): number {
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = canvas.offsetWidth;
+  const cssH = canvas.offsetHeight;
+  const bufW = Math.round(cssW * dpr);
+  const bufH = Math.round(cssH * dpr);
+  if (cssW > 0 && cssH > 0 && (canvas.width !== bufW || canvas.height !== bufH)) {
+    canvas.width = bufW;
+    canvas.height = bufH;
+  }
+  return dpr;
+}
+
+export function distanceToSegment(
+  point: { x: number; y: number },
+  p1: { x: number; y: number },
+  p2: { x: number; y: number },
+): number {
+  const dx = p2.x - p1.x;
+  const dy = p2.y - p1.y;
+  if (dx === 0 && dy === 0) {
+    const pdx = point.x - p1.x;
+    const pdy = point.y - p1.y;
+    return Math.sqrt(pdx * pdx + pdy * pdy);
+  }
+  const t = Math.max(0, Math.min(1, ((point.x - p1.x) * dx + (point.y - p1.y) * dy) / (dx * dx + dy * dy)));
+  const projX = p1.x + t * dx;
+  const projY = p1.y + t * dy;
+  const pdx = point.x - projX;
+  const pdy = point.y - projY;
+  return Math.sqrt(pdx * pdx + pdy * pdy);
+}
+
+export function generateId(): string {
+  return Math.random().toString(36).substring(2, 11);
+}

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -13,6 +13,11 @@ export const queryKeys = {
   },
   worships: {
     all: ["worships"] as const,
+    // 무한 스크롤 목록 — 필터 상태를 key에 포함. all의 prefix라 기존 invalidate가 자동 커버
+    list: (filters: { typeId?: string; q?: string; year?: string; month?: string; limit?: number }) =>
+      ["worships", "list", filters] as const,
+    // 연도 목록 — worships prefix 아래 둬서 예배 mutation의 invalidate(["worships"])에 자동 포함
+    years: ["worships", "years"] as const,
     detail: (id: string) => ["worships", id] as const,
   },
   commands: {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -16,7 +16,7 @@ createRoot(document.getElementById("root")!).render(
       persistOptions={{
         persister: asyncStoragePersister,
         maxAge: 1000 * 60 * 60 * 24 * 7, // 7일
-        buster: "v2", // 스키마 변경 시 이 값을 올리면 캐시 자동 무효화 (v2: 영속화에서 drawings 제외)
+        buster: "v3", // 스키마 변경 시 이 값을 올리면 캐시 자동 무효화 (v3: worships 무한쿼리 페이지네이션 응답)
         dehydrateOptions: {
           // drawings는 실시간으로 바뀌는 ephemeral 데이터 — 디스크에 영속화하면
           // 다음 세션에서 오래되거나 이미 지워진 stroke 스냅샷이 되살아남

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Toaster } from "sonner";
 import { queryClient, asyncStoragePersister } from "./lib/queryClient";
 import { router } from "./routes";
+import "pretendard/dist/web/variable/pretendardvariable.css";
 import "./globals.css";
 
 createRoot(document.getElementById("root")!).render(

--- a/client/src/pages/CommandSetup.tsx
+++ b/client/src/pages/CommandSetup.tsx
@@ -41,21 +41,21 @@ export default function CommandSetup() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>
             <Link to="/">
-              <ArrowLeft className="w-6 h-6 text-slate-600" />
+              <ArrowLeft className="w-6 h-6 text-muted-foreground" />
             </Link>
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">명령 설정</h1>
-            <p className="text-slate-600">예배 중 사용할 명령을 관리하세요</p>
+            <h1 className="text-3xl font-bold text-foreground">명령 설정</h1>
+            <p className="text-muted-foreground">예배 중 사용할 명령을 관리하세요</p>
           </div>
           <ConfirmDialog
             trigger={
-              <Button variant="secondary" className="bg-orange-50 text-orange-600 hover:bg-orange-100">
+              <Button variant="secondary">
                 <RotateCcw className="w-5 h-5" />
                 초기화
               </Button>
@@ -72,7 +72,7 @@ export default function CommandSetup() {
         <Card className="mb-6 rounded-3xl p-8">
           <CardContent className="p-0">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-xl font-bold text-slate-800">현재 명령 ({commands.length})</h2>
+              <h2 className="text-xl font-bold text-foreground">현재 명령 ({commands.length})</h2>
               <Dialog
                 open={dialogOpen}
                 onOpenChange={(open) => {
@@ -91,7 +91,7 @@ export default function CommandSetup() {
                   </DialogHeader>
                   <div className="space-y-6">
                     <div>
-                      <label className="block text-sm font-semibold text-slate-700 mb-2">이모티콘 *</label>
+                      <label className="block text-sm font-semibold text-foreground mb-2">이모티콘 *</label>
                       <Input
                         type="text"
                         value={newEmoji}
@@ -101,7 +101,7 @@ export default function CommandSetup() {
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-semibold text-slate-700 mb-2">명령 이름 *</label>
+                      <label className="block text-sm font-semibold text-foreground mb-2">명령 이름 *</label>
                       <Input
                         type="text"
                         value={newLabel}
@@ -110,11 +110,11 @@ export default function CommandSetup() {
                         className="text-lg"
                       />
                     </div>
-                    <div className="p-6 bg-linear-to-br from-slate-50 to-slate-100 rounded-2xl">
-                      <div className="text-sm font-semibold text-slate-600 mb-3 text-center">미리보기</div>
+                    <div className="p-6 bg-muted rounded-2xl">
+                      <div className="text-sm font-semibold text-muted-foreground mb-3 text-center">미리보기</div>
                       <div className="flex flex-col items-center gap-3">
                         <span className="text-7xl">{newEmoji || "🎵"}</span>
-                        <span className="text-lg font-semibold text-slate-700">{newLabel || "명령 이름"}</span>
+                        <span className="text-lg font-semibold text-foreground">{newLabel || "명령 이름"}</span>
                       </div>
                     </div>
                   </div>
@@ -134,23 +134,20 @@ export default function CommandSetup() {
             {commands.length > 0 ? (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
                 {commands.map((command) => (
-                  <Card
-                    key={command.id}
-                    className="bg-linear-to-br from-slate-50 to-slate-100 rounded-2xl p-6 shadow-md border-2 border-transparent"
-                  >
+                  <Card key={command.id} className="bg-muted rounded-2xl p-6 shadow-md border-2 border-transparent">
                     <CardContent className="p-0">
                       <div className="flex flex-col items-center gap-3 mb-3">
                         <span className="text-6xl">{command.emoji}</span>
-                        <span className="text-sm font-semibold text-slate-700 text-center">{command.label}</span>
+                        <span className="text-sm font-semibold text-foreground text-center">{command.label}</span>
                         {command.isDefault && (
-                          <span className="px-3 py-1 bg-blue-100 text-blue-600 text-xs font-semibold rounded-full">
+                          <span className="px-3 py-1 bg-accent text-accent-foreground text-xs font-semibold rounded-full">
                             기본 명령
                           </span>
                         )}
                       </div>
                       <ConfirmDialog
                         trigger={
-                          <Button variant="destructive" className="w-full border-2 border-red-200">
+                          <Button variant="destructive" className="w-full border-2 border-destructive/30">
                             <Trash2 className="w-4 h-4" />
                             <span className="text-sm font-semibold">삭제</span>
                           </Button>
@@ -166,21 +163,19 @@ export default function CommandSetup() {
                 ))}
               </div>
             ) : (
-              <div className="text-center py-16 bg-slate-50 rounded-xl border-2 border-dashed border-slate-300">
-                <div className="w-16 h-16 bg-slate-200 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <Settings className="w-8 h-8 text-slate-400" />
+              <div className="text-center py-16 bg-muted rounded-xl border-2 border-dashed border-border">
+                <div className="w-16 h-16 bg-secondary rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <Settings className="w-8 h-8 text-muted-foreground" />
                 </div>
-                <h3 className="text-lg font-semibold text-slate-700 mb-2">아직 명령이 없습니다</h3>
-                <p className="text-slate-500 mb-6">새 명령을 추가하거나 초기화 버튼으로 기본 명령을 불러오세요</p>
+                <h3 className="text-lg font-semibold text-foreground mb-2">아직 명령이 없습니다</h3>
+                <p className="text-muted-foreground mb-6">
+                  새 명령을 추가하거나 초기화 버튼으로 기본 명령을 불러오세요
+                </p>
                 <div className="flex items-center justify-center gap-3">
                   <Button onClick={() => setDialogOpen(true)}>
                     <Plus className="w-5 h-5" />새 명령 추가
                   </Button>
-                  <Button
-                    variant="secondary"
-                    className="bg-orange-50 text-orange-600 hover:bg-orange-100"
-                    onClick={() => resetCommandsMutation.mutate()}
-                  >
+                  <Button variant="secondary" onClick={() => resetCommandsMutation.mutate()}>
                     <RotateCcw className="w-5 h-5" />
                     기본 명령 초기화
                   </Button>
@@ -191,9 +186,9 @@ export default function CommandSetup() {
         </Card>
 
         {/* 안내 */}
-        <div className="bg-linear-to-br from-blue-50 to-purple-50 rounded-2xl p-6 border-2 border-blue-100">
-          <h3 className="font-bold text-slate-800 mb-2">명령 사용 안내</h3>
-          <ul className="space-y-2 text-sm text-slate-600">
+        <div className="bg-accent rounded-2xl p-6 border-2 border-border">
+          <h3 className="font-bold text-foreground mb-2">명령 사용 안내</h3>
+          <ul className="space-y-2 text-sm text-muted-foreground">
             <li>- 모든 명령을 삭제할 수 있으며, 삭제된 기본 명령은 초기화 시 복구됩니다</li>
             <li>- 커스텀 명령은 자유롭게 추가/삭제할 수 있습니다</li>
             <li>- 전송된 명령은 모든 세션 멤버에게 실시간으로 표시됩니다</li>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -30,7 +30,7 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-4xl mx-auto">
         {/* 헤더 */}
         <div className="relative text-center mb-12">
@@ -38,23 +38,23 @@ export default function Home() {
             <Button
               variant="ghost"
               size="icon"
-              className="absolute top-0 right-0 text-slate-400 hover:text-slate-600"
+              className="absolute top-0 right-0 text-muted-foreground hover:text-foreground"
               onClick={() => logout.mutate()}
               disabled={logout.isPending}
             >
               <LogOut className="w-5 h-5" />
             </Button>
           )}
-          <img src="/pwa-192x192.png" alt="길튼 시스템" className="mx-auto w-24 h-24 rounded-3xl mb-6 shadow-lg" />
-          <h1 className="text-5xl font-bold text-slate-800 mb-3">길튼 시스템</h1>
-          <p className="text-xl text-slate-600">예배 찬양 지원 시스템</p>
+          <img src="/pwa-192x192.png" alt="길튼 시스템" className="mx-auto w-24 h-24 rounded-3xl mb-6 shadow-sm" />
+          <h1 className="text-5xl font-bold text-foreground mb-3 tracking-tight">길튼 시스템</h1>
+          <p className="text-xl text-muted-foreground">예배 찬양 지원 시스템</p>
         </div>
 
         {/* 프로필 선택 */}
-        <Card className="rounded-3xl mb-6">
+        <Card className="rounded-2xl mb-6">
           <CardContent className="p-8">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-bold text-slate-800">프로필 선택</h2>
+              <h2 className="text-2xl font-bold text-foreground">프로필 선택</h2>
               <Button asChild>
                 <Link to="/profile-setup/new">
                   <Plus className="w-5 h-5" />
@@ -71,7 +71,7 @@ export default function Home() {
                     <button
                       key={profile.id}
                       onClick={() => handleProfileSelect(profile.id)}
-                      className="group relative bg-linear-to-br from-slate-50 to-slate-100 rounded-2xl p-6 hover:shadow-xl transition-all duration-200 border-2 border-transparent hover:border-blue-300 active:scale-95 text-left"
+                      className="group relative bg-muted rounded-2xl p-6 hover:shadow-md transition-all duration-200 border-2 border-transparent hover:border-primary/40 active:scale-95 text-left"
                     >
                       <div className="flex items-center gap-4">
                         <div
@@ -80,11 +80,8 @@ export default function Home() {
                           {role?.icon}
                         </div>
                         <div className="flex-1">
-                          <h3 className="text-xl font-bold text-slate-800 mb-1">{profile.name}</h3>
-                          <Badge
-                            variant="secondary"
-                            className="px-3 py-1 text-sm font-semibold bg-slate-200 text-slate-700"
-                          >
+                          <h3 className="text-xl font-bold text-foreground mb-1">{profile.name}</h3>
+                          <Badge variant="secondary" className="px-3 py-1 text-sm font-semibold">
                             {role?.name}
                           </Badge>
                         </div>
@@ -94,12 +91,12 @@ export default function Home() {
                 })}
               </div>
             ) : (
-              <div className="text-center py-12 bg-slate-50 rounded-2xl border-2 border-dashed border-slate-300">
-                <div className="w-16 h-16 bg-slate-200 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <UserCircle className="w-8 h-8 text-slate-400" />
+              <div className="text-center py-12 bg-muted rounded-2xl border-2 border-dashed border-border">
+                <div className="w-16 h-16 bg-secondary rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <UserCircle className="w-8 h-8 text-muted-foreground" />
                 </div>
-                <h3 className="text-lg font-semibold text-slate-700 mb-2">프로필이 없습니다</h3>
-                <p className="text-slate-500 mb-6">먼저 프로필을 생성해주세요</p>
+                <h3 className="text-lg font-semibold text-foreground mb-2">프로필이 없습니다</h3>
+                <p className="text-muted-foreground mb-6">먼저 프로필을 생성해주세요</p>
                 <Button asChild>
                   <Link to="/profile-setup/new">
                     <Plus className="w-5 h-5" />
@@ -118,11 +115,11 @@ export default function Home() {
               key={to}
               asChild
               variant="ghost"
-              className="w-full p-6 h-auto rounded-2xl bg-white shadow-sm border hover:bg-slate-100"
+              className="w-full p-6 h-auto rounded-2xl bg-card shadow-sm border border-border hover:bg-accent"
             >
               <Link to={to}>
-                <Icon className="w-6 h-6 text-slate-600" />
-                <span className="text-lg font-semibold text-slate-700">{label}</span>
+                <Icon className="w-6 h-6 text-primary" />
+                <span className="text-lg font-semibold text-foreground">{label}</span>
               </Link>
             </Button>
           ))}

--- a/client/src/pages/PinLock.tsx
+++ b/client/src/pages/PinLock.tsx
@@ -19,15 +19,15 @@ export default function PinLock() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 flex items-center justify-center p-8">
+    <div className="min-h-screen bg-background flex items-center justify-center p-8">
       <Card className="rounded-3xl w-full max-w-sm">
         <CardContent className="p-8">
           <div className="text-center mb-8">
-            <div className="w-16 h-16 bg-slate-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Lock className="w-8 h-8 text-slate-600" />
+            <div className="w-16 h-16 bg-muted rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <Lock className="w-8 h-8 text-muted-foreground" />
             </div>
-            <h1 className="text-2xl font-bold text-slate-800 mb-2">길튼 시스템</h1>
-            <p className="text-slate-500">PIN을 입력해주세요</p>
+            <h1 className="text-2xl font-bold text-foreground mb-2">길튼 시스템</h1>
+            <p className="text-muted-foreground">PIN을 입력해주세요</p>
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">

--- a/client/src/pages/ProfileEdit.tsx
+++ b/client/src/pages/ProfileEdit.tsx
@@ -58,7 +58,7 @@ export default function ProfileEdit() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>
@@ -67,8 +67,8 @@ export default function ProfileEdit() {
             </Link>
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">{isNewProfile ? "새 프로필 추가" : "프로필 수정"}</h1>
-            <p className="text-slate-600">프로필 정보를 입력하세요</p>
+            <h1 className="text-3xl font-bold text-foreground">{isNewProfile ? "새 프로필 추가" : "프로필 수정"}</h1>
+            <p className="text-muted-foreground">프로필 정보를 입력하세요</p>
           </div>
         </div>
 
@@ -80,15 +80,15 @@ export default function ProfileEdit() {
                 <div className={`w-32 h-32 ${color} rounded-3xl flex items-center justify-center text-7xl shadow-xl`}>
                   {getRoleById(roleId)?.icon}
                 </div>
-                <div className="absolute -bottom-2 -right-2 bg-white rounded-full p-2 shadow-lg">
-                  <User className="w-6 h-6 text-slate-600" />
+                <div className="absolute -bottom-2 -right-2 bg-card rounded-full p-2 shadow-lg">
+                  <User className="w-6 h-6 text-muted-foreground" />
                 </div>
               </div>
             </div>
 
             {/* 이름 */}
             <div className="mb-6">
-              <label className="block text-sm font-semibold text-slate-700 mb-2">이름 *</label>
+              <label className="block text-sm font-semibold text-foreground mb-2">이름 *</label>
               <Input
                 type="text"
                 value={name}
@@ -100,7 +100,7 @@ export default function ProfileEdit() {
 
             {/* 역할 선택 */}
             <div className="mb-6">
-              <label className="block text-sm font-semibold text-slate-700 mb-3">역할 *</label>
+              <label className="block text-sm font-semibold text-foreground mb-3">역할 *</label>
               {roles.length > 0 ? (
                 <div className="grid grid-cols-3 gap-3">
                   {roles.map((role) => (
@@ -109,8 +109,8 @@ export default function ProfileEdit() {
                       onClick={() => setRoleId(role.id)}
                       className={`flex items-center justify-center gap-2 py-4 rounded-xl font-semibold transition-all ${
                         roleId === role.id
-                          ? "bg-blue-600 text-white shadow-lg scale-105"
-                          : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+                          ? "bg-primary text-primary-foreground shadow-lg scale-105"
+                          : "bg-muted text-foreground hover:bg-secondary"
                       }`}
                     >
                       <span className="text-2xl">{role.icon}</span>
@@ -137,7 +137,7 @@ export default function ProfileEdit() {
 
             {/* 색상 선택 */}
             <div className="mb-8">
-              <label className="block text-sm font-semibold text-slate-700 mb-3">배경 색상</label>
+              <label className="block text-sm font-semibold text-foreground mb-3">배경 색상</label>
               <div className="grid grid-cols-6 gap-3">
                 {PROFILE_COLORS.map((c) => (
                   <button

--- a/client/src/pages/ProfileSetup.tsx
+++ b/client/src/pages/ProfileSetup.tsx
@@ -13,7 +13,7 @@ export default function ProfileSetup() {
   const getRoleById = (roleId: string) => roles.find((r) => r.id === roleId);
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-3xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>
@@ -22,8 +22,8 @@ export default function ProfileSetup() {
             </Link>
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">프로필 관리</h1>
-            <p className="text-slate-600">프로필을 추가하거나 수정하세요</p>
+            <h1 className="text-3xl font-bold text-foreground">프로필 관리</h1>
+            <p className="text-muted-foreground">프로필을 추가하거나 수정하세요</p>
           </div>
           <Button asChild>
             <Link to="/profile-setup/new">
@@ -32,15 +32,15 @@ export default function ProfileSetup() {
           </Button>
         </div>
 
-        <div className="bg-white rounded-3xl shadow-xl p-8">
-          <h2 className="text-xl font-bold text-slate-800 mb-6">프로필 목록 ({profiles.length}개)</h2>
+        <div className="bg-card rounded-3xl shadow-xl p-8">
+          <h2 className="text-xl font-bold text-foreground mb-6">프로필 목록 ({profiles.length}개)</h2>
 
           {profiles.length > 0 ? (
             <div className="space-y-3">
               {profiles.map((profile) => (
                 <div
                   key={profile.id}
-                  className="flex items-center justify-between p-5 bg-linear-to-r from-slate-50 to-slate-100 rounded-xl hover:shadow-md transition-all border-2 border-transparent hover:border-blue-200"
+                  className="flex items-center justify-between p-5 bg-muted rounded-xl hover:shadow-md transition-all border-2 border-transparent hover:border-primary/40"
                 >
                   <div className="flex items-center gap-4">
                     <div
@@ -49,7 +49,7 @@ export default function ProfileSetup() {
                       {getRoleById(profile.roleId)?.icon}
                     </div>
                     <div>
-                      <div className="font-bold text-lg text-slate-800">{profile.name}</div>
+                      <div className="font-bold text-lg text-foreground">{profile.name}</div>
                       <Badge variant="secondary" className="mt-1">
                         {getRoleById(profile.roleId)?.name}
                       </Badge>
@@ -77,12 +77,12 @@ export default function ProfileSetup() {
               ))}
             </div>
           ) : (
-            <div className="text-center py-16 bg-slate-50 rounded-xl border-2 border-dashed border-slate-300">
-              <div className="w-16 h-16 bg-slate-200 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                <User className="w-8 h-8 text-slate-400" />
+            <div className="text-center py-16 bg-muted rounded-xl border-2 border-dashed border-border">
+              <div className="w-16 h-16 bg-secondary rounded-2xl flex items-center justify-center mx-auto mb-4">
+                <User className="w-8 h-8 text-muted-foreground" />
               </div>
-              <h3 className="text-lg font-semibold text-slate-700 mb-2">아직 프로필이 없습니다</h3>
-              <p className="text-slate-500 mb-6">새 프로필 버튼을 눌러 프로필을 만드세요</p>
+              <h3 className="text-lg font-semibold text-foreground mb-2">아직 프로필이 없습니다</h3>
+              <p className="text-muted-foreground mb-6">새 프로필 버튼을 눌러 프로필을 만드세요</p>
               <Button asChild>
                 <Link to="/profile-setup/new">
                   <Plus className="w-5 h-5" />새 프로필 추가

--- a/client/src/pages/RoleManagement.tsx
+++ b/client/src/pages/RoleManagement.tsx
@@ -59,7 +59,7 @@ export default function RoleManagement() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>
@@ -68,8 +68,8 @@ export default function RoleManagement() {
             </Link>
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">역할 관리</h1>
-            <p className="text-slate-600">팀원의 역할을 추가하고 관리하세요</p>
+            <h1 className="text-3xl font-bold text-foreground">역할 관리</h1>
+            <p className="text-muted-foreground">팀원의 역할을 추가하고 관리하세요</p>
           </div>
           {!isAdding && !editingId && (
             <Button onClick={() => setIsAdding(true)}>
@@ -80,12 +80,12 @@ export default function RoleManagement() {
 
         {/* 추가 폼 */}
         {isAdding && (
-          <Card className="mb-6 border-2 border-blue-200">
+          <Card className="mb-6 border-2 border-border">
             <CardContent>
-              <h3 className="text-lg font-bold text-slate-800 mb-4">새 역할 추가</h3>
+              <h3 className="text-lg font-bold text-foreground mb-4">새 역할 추가</h3>
               <div className="grid grid-cols-2 gap-4 mb-4">
                 <div>
-                  <label className="block text-sm font-semibold text-slate-700 mb-2">역할 이름</label>
+                  <label className="block text-sm font-semibold text-foreground mb-2">역할 이름</label>
                   <Input
                     type="text"
                     value={formData.name}
@@ -94,7 +94,7 @@ export default function RoleManagement() {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-semibold text-slate-700 mb-2">이모지 아이콘</label>
+                  <label className="block text-sm font-semibold text-foreground mb-2">이모지 아이콘</label>
                   <Input
                     type="text"
                     value={formData.icon}
@@ -127,7 +127,7 @@ export default function RoleManagement() {
                 <Card
                   key={role.id}
                   className={
-                    isEditing ? "border-2 border-blue-200" : "border-2 border-transparent hover:border-blue-100"
+                    isEditing ? "border-2 border-border" : "border-2 border-transparent hover:border-primary/40"
                   }
                 >
                   <CardContent>
@@ -135,7 +135,7 @@ export default function RoleManagement() {
                       <div>
                         <div className="grid grid-cols-2 gap-4 mb-4">
                           <div>
-                            <label className="block text-sm font-semibold text-slate-700 mb-2">역할 이름</label>
+                            <label className="block text-sm font-semibold text-foreground mb-2">역할 이름</label>
                             <Input
                               type="text"
                               value={formData.name}
@@ -143,7 +143,7 @@ export default function RoleManagement() {
                             />
                           </div>
                           <div>
-                            <label className="block text-sm font-semibold text-slate-700 mb-2">이모지 아이콘</label>
+                            <label className="block text-sm font-semibold text-foreground mb-2">이모지 아이콘</label>
                             <Input
                               type="text"
                               value={formData.icon}
@@ -165,13 +165,13 @@ export default function RoleManagement() {
                     ) : (
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-4">
-                          <div className="w-16 h-16 bg-linear-to-br from-blue-500 to-purple-600 rounded-xl flex items-center justify-center text-3xl shadow-md">
+                          <div className="w-16 h-16 bg-primary rounded-xl flex items-center justify-center text-3xl shadow-sm">
                             {role.icon}
                           </div>
                           <div>
-                            <h3 className="text-xl font-bold text-slate-800">{role.name}</h3>
+                            <h3 className="text-xl font-bold text-foreground">{role.name}</h3>
                             {inUse && (
-                              <div className="flex items-center gap-1 text-sm text-blue-600 mt-1">
+                              <div className="flex items-center gap-1 text-sm text-primary mt-1">
                                 <AlertCircle className="w-4 h-4" />
                                 사용 중
                               </div>
@@ -183,7 +183,12 @@ export default function RoleManagement() {
                             <Edit className="w-5 h-5" />
                           </Button>
                           {inUse ? (
-                            <Button variant="ghost" size="icon" disabled className="text-slate-400 cursor-not-allowed">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              disabled
+                              className="text-muted-foreground cursor-not-allowed"
+                            >
                               <Trash2 className="w-5 h-5" />
                             </Button>
                           ) : (
@@ -209,12 +214,12 @@ export default function RoleManagement() {
             })}
           </div>
         ) : (
-          <div className="text-center py-16 bg-slate-50 rounded-xl border-2 border-dashed border-slate-300">
-            <div className="w-16 h-16 bg-slate-200 rounded-2xl flex items-center justify-center mx-auto mb-4">
-              <Users className="w-8 h-8 text-slate-400" />
+          <div className="text-center py-16 bg-muted rounded-xl border-2 border-dashed border-border">
+            <div className="w-16 h-16 bg-secondary rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <Users className="w-8 h-8 text-muted-foreground" />
             </div>
-            <h3 className="text-lg font-semibold text-slate-700 mb-2">아직 역할이 없습니다</h3>
-            <p className="text-slate-500 mb-6">새 역할 추가 버튼을 눌러 역할을 만드세요</p>
+            <h3 className="text-lg font-semibold text-foreground mb-2">아직 역할이 없습니다</h3>
+            <p className="text-muted-foreground mb-6">새 역할 추가 버튼을 눌러 역할을 만드세요</p>
             <Button onClick={() => setIsAdding(true)}>
               <Plus className="w-5 h-5" />새 역할 추가
             </Button>
@@ -222,10 +227,10 @@ export default function RoleManagement() {
         )}
 
         {roles.length > 0 && (
-          <Card className="mt-6 bg-linear-to-br from-blue-50 to-blue-100 border-2 border-blue-200">
+          <Card className="mt-6 bg-accent border-2 border-border">
             <CardContent>
-              <div className="text-sm font-semibold text-blue-700 mb-1">전체 역할</div>
-              <div className="text-3xl font-bold text-blue-900">{roles.length}개</div>
+              <div className="text-sm font-semibold text-accent-foreground mb-1">전체 역할</div>
+              <div className="text-3xl font-bold text-accent-foreground">{roles.length}개</div>
             </CardContent>
           </Card>
         )}

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -1,30 +1,8 @@
 import { useState, useRef, useEffect, useCallback, useMemo, type CSSProperties } from "react";
-import { Link, useParams, useNavigate } from "react-router";
-import {
-  ChevronLeft,
-  ChevronRight,
-  Pencil,
-  Eye,
-  Eraser,
-  Undo,
-  Redo,
-  ArrowLeft,
-  Users,
-  Menu,
-  Minus,
-  Plus as PlusIcon,
-  Edit,
-  Trash,
-  FileMusic,
-  Upload,
-  Megaphone,
-  Palette,
-} from "lucide-react";
+import { useParams, useNavigate } from "react-router";
+import { Upload } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { toast } from "sonner";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useWorship, useCommands, useSheetDrawings, useAdjacentDrawingsPreload } from "@/hooks/queries";
 import { useAppStore } from "@/store/appStore";
 import { useWorshipSocket } from "@/hooks/useWorshipSocket";
@@ -37,10 +15,11 @@ import { useAdjacentSheetPreload } from "@/hooks/useAdjacentSheetPreload";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useSheetPageMotion } from "@/hooks/useSheetPageMotion";
 import { useSheetZoomPan } from "@/hooks/useSheetZoomPan";
-
-const PANEL_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
-const panelTransition = { duration: 0.22, ease: PANEL_EASE };
-const panelContentTransition = { duration: 0.16, ease: PANEL_EASE };
+import WorshipHeader from "@/components/worship/WorshipHeader";
+import SheetListSidebar from "@/components/worship/SheetListSidebar";
+import DrawingToolbar, { type DrawingToolState, type DrawingToolActions } from "@/components/worship/DrawingToolbar";
+import CommandPanel from "@/components/worship/CommandPanel";
+import PageNavigator from "@/components/worship/PageNavigator";
 
 // 악보 카드 sizing — 부모(container-type:size) 안에 항상 3:4로 contain.
 // 너비 clamp로 비율이 깨지면 canvas가 비등방 stretch되어 stroke가 어긋나므로 비율을 고정한다.
@@ -105,7 +84,7 @@ export default function Worship() {
   } = useSheetZoomPan({ containerRef: sheetContainerRef, isDrawModeRef, cancelPageMotionRef });
 
   const sheets = useMemo(() => worshipData?.sheets || [], [worshipData?.sheets]);
-  const currentSheet = sheets.find((s) => s.id === currentSheetId) || null;
+  const currentSheet = useMemo(() => sheets.find((s) => s.id === currentSheetId) || null, [sheets, currentSheetId]);
   const currentPage = sheets.findIndex((s) => s.id === currentSheetId);
 
   const socket = getSocket();
@@ -233,16 +212,19 @@ export default function Worship() {
   const previewTargetSheet = activeTargetPage !== null ? sheets[activeTargetPage] : null;
   const { data: previewDrawings } = useSheetDrawings(previewTargetSheet?.id ?? null);
 
-  const handleSendCommand = (command: { id: string; emoji: string; label: string }) => {
-    if (!id || !currentProfileId) return;
-    socket.emit("command:send", {
-      worshipId: id,
-      commandId: command.id,
-      profileId: currentProfileId,
-    });
-  };
+  const handleSendCommand = useCallback(
+    (command: { id: string; emoji: string; label: string }) => {
+      if (!id || !currentProfileId) return;
+      socket.emit("command:send", {
+        worshipId: id,
+        commandId: command.id,
+        profileId: currentProfileId,
+      });
+    },
+    [id, currentProfileId, socket],
+  );
 
-  const handleSpotlightCall = () => {
+  const handleSpotlightCall = useCallback(() => {
     if (!id || !currentProfileId || !currentSheet) return;
     socket.emit("page:spotlight", {
       worshipId: id,
@@ -251,93 +233,43 @@ export default function Worship() {
       profileId: currentProfileId,
     });
     toast.success("현재 페이지를 호출했습니다");
-  };
+  }, [id, currentProfileId, currentSheet, socket]);
+
+  const handleToggleSidebar = useCallback(() => setShowSidebar((s) => !s), []);
+  const handleToggleCommandPanel = useCallback(() => setShowCommandPanel((s) => !s), []);
+
+  const drawingTool: DrawingToolState = useMemo(
+    () => ({ isDrawMode, selectedColor, penWidth, eraserType, eraserWidth, toolPopoverOpen }),
+    [isDrawMode, selectedColor, penWidth, eraserType, eraserWidth, toolPopoverOpen],
+  );
+
+  const drawingActions: DrawingToolActions = useMemo(
+    () => ({
+      setIsDrawMode,
+      setSelectedColor,
+      setPenWidth,
+      setEraserType,
+      setEraserWidth,
+      setToolPopoverOpen,
+      undo: drawingUndo,
+      redo: drawingRedo,
+      setIsCompact,
+    }),
+    [drawingUndo, drawingRedo],
+  );
 
   return (
     <div className="h-dvh flex flex-col bg-slate-900">
-      {/* 상단 헤더 (컴팩트 시 세로 콜랩스 + 페이드 — 찌그러짐 없는 push) */}
-      <div
-        className="grid"
-        style={{
-          gridTemplateRows: isCompact ? "0fr" : "1fr",
-          transition: "grid-template-rows var(--dur-panel) var(--ease-out)",
-        }}
-      >
-        <div className="overflow-hidden">
-          <header
-            className="bg-slate-800 border-b border-slate-700 px-6 py-4 flex items-center justify-between"
-            style={{
-              opacity: isCompact ? 0 : 1,
-              transform: isCompact ? "translateY(-100%)" : "translateY(0)",
-              transition: "opacity var(--dur-panel) var(--ease-out), transform var(--dur-panel) var(--ease-out)",
-            }}
-            inert={isCompact}
-          >
-            <div className="flex items-center gap-4">
-              <Button variant="ghost" size="icon" className="hover:bg-slate-700 text-slate-300" asChild>
-                <Link to="/worship-list">
-                  <ArrowLeft className="w-6 h-6" />
-                </Link>
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-slate-700 text-slate-300"
-                onClick={() => setShowSidebar(!showSidebar)}
-              >
-                <Menu className="w-6 h-6" />
-              </Button>
-              <div className="h-8 w-px bg-slate-600" />
-              <h1 className="text-xl font-bold text-white">{worshipData?.title || "예배"}</h1>
-            </div>
-
-            <div className="flex items-center gap-3">
-              {/* 서버 연결 상태 인디케이터 */}
-              {!isConnected && (
-                <div className="flex items-center gap-2 px-3 py-1.5 bg-red-600/20 border border-red-500/30 rounded-lg">
-                  <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
-                  <span className="text-xs font-medium text-red-400">연결 끊김</span>
-                </div>
-              )}
-              <Button variant="ghost" size="sm" className="bg-slate-700 text-slate-300 hover:bg-slate-600" asChild>
-                <Link to={`/worship-edit/${id}`}>
-                  <Edit className="w-5 h-5" />
-                  <span>편집</span>
-                </Link>
-              </Button>
-              {/* 컴팩트 시 헤더가 접히면 포털된 PopoverContent도 함께 닫음(inert는 포털 밖을 못 막음) */}
-              <Popover open={presencePopoverOpen && !isCompact} onOpenChange={setPresencePopoverOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="bg-slate-700 text-slate-300 hover:bg-slate-600 cursor-pointer"
-                  >
-                    <Users className="w-5 h-5" />
-                    <span>{presenceUsers.length}명 접속</span>
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-64 bg-slate-800 border-slate-700 p-0" align="end">
-                  <div className="p-3 border-b border-slate-700">
-                    <h3 className="text-sm font-semibold text-white">접속 중인 사용자</h3>
-                  </div>
-                  <div className="p-2 max-h-60 overflow-y-auto">
-                    {presenceUsers.map((user) => (
-                      <div key={user.profileId} className="flex items-center gap-3 px-2 py-2 rounded-lg">
-                        <span className="text-lg">{user.roleIcon}</span>
-                        <div className="flex-1 min-w-0">
-                          <div className="text-sm font-medium text-white truncate">{user.name}</div>
-                          <div className="text-xs text-slate-400">{user.role}</div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
-          </header>
-        </div>
-      </div>
+      <WorshipHeader
+        worshipTitle={worshipData?.title}
+        worshipId={id}
+        isCompact={isCompact}
+        isConnected={isConnected}
+        presenceUsers={presenceUsers}
+        presencePopoverOpen={presencePopoverOpen}
+        onPresencePopoverChange={setPresencePopoverOpen}
+        onToggleSidebar={handleToggleSidebar}
+      />
 
       {/* 컴팩트 모드: 연결 끊김 시 플로팅 인디케이터 */}
       {isCompact && !isConnected && (
@@ -348,329 +280,31 @@ export default function Worship() {
       )}
 
       <div className="flex-1 flex overflow-hidden">
-        {/* 좌측 악보 리스트 */}
-        <motion.aside
-          aria-hidden={!showSidebar}
-          inert={!showSidebar}
-          initial={false}
-          animate={showSidebar ? { width: "16rem", opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: -12 }}
-          transition={shouldReduceMotion ? { duration: 0 } : panelTransition}
-          className={cn("shrink-0 bg-slate-800 overflow-hidden", showSidebar && "border-r border-slate-700")}
-          style={{ pointerEvents: showSidebar ? "auto" : "none" }}
-        >
-          {/* 좌측은 첫 flex 항목이라 콘텐츠가 화면 끝에 고정됨 → 내부 독립 translate를
-              쓰면 프레임과 분리된 parallax로 보인다. opacity만 페이드하고 슬라이드는
-              aside의 x(-12→0)에 맡겨 패널 전체가 한 덩어리로 움직이게 한다.
-              (우측 패널은 콘텐츠가 움직이는 divider를 따라가 통합 슬라이드로 읽히므로 내부 x 유지) */}
-          <motion.div
-            animate={showSidebar ? { opacity: 1 } : { opacity: 0 }}
-            transition={shouldReduceMotion ? { duration: 0 } : panelContentTransition}
-            className="w-64 h-full overflow-y-auto p-4 box-border"
-          >
-            <h2 className="text-lg font-bold text-white mb-4">악보 목록</h2>
-
-            {sheets.length > 0 ? (
-              <div className="space-y-2">
-                {sheets.map((sheet, index) => {
-                  const usersOnSheet = presenceUsers.filter((u) => u.sheetId === sheet.id);
-                  return (
-                    <button
-                      key={sheet.id}
-                      onClick={() => commitPage(index)}
-                      className={`w-full text-left p-4 rounded-xl cursor-pointer transition-colors ${
-                        currentSheetId === sheet.id
-                          ? "bg-blue-600 text-white shadow-lg"
-                          : "bg-slate-700 text-slate-300 hover:bg-slate-600"
-                      }`}
-                    >
-                      <div className="flex items-center gap-3">
-                        <FileMusic className="w-5 h-5" />
-                        <div className="flex-1 min-w-0">
-                          <div className="font-semibold mb-1 line-clamp-2">{sheet.title}</div>
-                          <div className="text-sm opacity-75">페이지 {index + 1}</div>
-                        </div>
-                        {usersOnSheet.length > 0 && (
-                          <div className="flex -space-x-1">
-                            {usersOnSheet.slice(0, 3).map((u) => (
-                              <span key={u.profileId} className="text-sm" title={`${u.name} (${u.role})`}>
-                                {u.roleIcon}
-                              </span>
-                            ))}
-                            {usersOnSheet.length > 3 && (
-                              <span className="text-xs text-slate-400 ml-1">+{usersOnSheet.length - 3}</span>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="text-center py-12 bg-slate-700 rounded-xl">
-                <FileMusic className="w-12 h-12 text-slate-500 mx-auto mb-3" />
-                <p className="text-slate-400 text-sm mb-4">악보가 없습니다</p>
-                <Button size="sm" className="bg-blue-600 hover:bg-blue-700" asChild>
-                  <Link to={`/worship-edit/${id}`}>
-                    <Edit className="w-4 h-4" />
-                    편집 페이지에서 추가
-                  </Link>
-                </Button>
-              </div>
-            )}
-          </motion.div>
-        </motion.aside>
+        <SheetListSidebar
+          show={showSidebar}
+          reducedMotion={!!shouldReduceMotion}
+          sheets={sheets}
+          currentSheetId={currentSheetId}
+          presenceUsers={presenceUsers}
+          worshipId={id}
+          onSelectPage={commitPage}
+        />
 
         {/* 중앙 악보 뷰어 */}
         <main
           className="flex-1 flex flex-col bg-slate-900"
           style={isDrawMode ? { touchAction: "none", overscrollBehaviorX: "none" } : undefined}
         >
-          {/* 도구 바 (컴팩트 시 세로 콜랩스 + 페이드) */}
-          <div
-            className="grid"
-            style={{
-              gridTemplateRows: isCompact ? "0fr" : "1fr",
-              transition: "grid-template-rows var(--dur-panel) var(--ease-out)",
-            }}
-          >
-            <div className="overflow-hidden">
-              <div
-                className="bg-slate-800 border-b border-slate-700 px-6 py-3 flex items-center justify-between"
-                style={{
-                  opacity: isCompact ? 0 : 1,
-                  transform: isCompact ? "translateY(-100%)" : "translateY(0)",
-                  transition: "opacity var(--dur-panel) var(--ease-out), transform var(--dur-panel) var(--ease-out)",
-                }}
-                inert={isCompact}
-              >
-                <div className="flex items-center gap-3">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      const next = !isDrawMode;
-                      setIsDrawMode(next);
-                      if (next) setIsCompact(false);
-                    }}
-                    className={cn(
-                      "px-5 py-2.5 rounded-xl",
-                      isDrawMode
-                        ? "bg-green-600 text-white shadow-lg hover:bg-green-700"
-                        : "bg-slate-700 text-slate-300 hover:bg-slate-600",
-                    )}
-                  >
-                    {isDrawMode ? (
-                      <>
-                        <Pencil className="w-5 h-5" />
-                        그리기 모드
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="w-5 h-5" />
-                        보기 모드
-                      </>
-                    )}
-                  </Button>
-
-                  {isDrawMode && (
-                    <>
-                      <Popover open={toolPopoverOpen} onOpenChange={setToolPopoverOpen}>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="bg-slate-700 text-slate-300 hover:bg-slate-600 px-4 py-2.5 rounded-xl"
-                          >
-                            <Palette className="w-5 h-5" />
-                            <span className="text-sm">도구</span>
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-80 bg-slate-800 border-slate-700 p-4" align="start">
-                          <div className="space-y-4">
-                            {/* 색상 팔레트 */}
-                            <div>
-                              <div className="text-xs font-semibold text-slate-400 mb-2">색상</div>
-                              <div className="flex items-center gap-2">
-                                {penColors.map((pen) => (
-                                  <button
-                                    key={pen.value}
-                                    onClick={() => {
-                                      setSelectedColor(pen.value);
-                                      setEraserType("none");
-                                    }}
-                                    className={`w-10 h-10 rounded-lg ${pen.color} transition-transform hover:scale-110 ${
-                                      selectedColor === pen.value && eraserType === "none"
-                                        ? `ring-4 scale-110 ${pen.value === "#ffffff" ? "ring-blue-400" : "ring-white"}`
-                                        : ""
-                                    }`}
-                                  />
-                                ))}
-                              </div>
-                            </div>
-
-                            {/* 펜 굵기 */}
-                            <div>
-                              <div className="text-xs font-semibold text-slate-400 mb-2">펜 굵기</div>
-                              <div className="flex items-center gap-2 bg-slate-700 rounded-lg px-3 py-2 w-fit">
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="p-1 h-auto w-auto hover:bg-slate-600 text-slate-300 rounded"
-                                  onClick={() => setPenWidth((p) => Math.max(p - 1, 1))}
-                                >
-                                  <Minus className="w-4 h-4" />
-                                </Button>
-                                <div className="text-slate-300 font-semibold min-w-7.5 text-center">{penWidth}</div>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="p-1 h-auto w-auto hover:bg-slate-600 text-slate-300 rounded"
-                                  onClick={() => setPenWidth((p) => Math.min(p + 1, 20))}
-                                >
-                                  <PlusIcon className="w-4 h-4" />
-                                </Button>
-                              </div>
-                            </div>
-
-                            {/* 지우개 */}
-                            <div>
-                              <div className="text-xs font-semibold text-slate-400 mb-2">지우개</div>
-                              <div className="flex items-center gap-2">
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => setEraserType((p) => (p === "area" ? "none" : "area"))}
-                                  className={cn(
-                                    "px-3 py-2.5 flex-1",
-                                    eraserType === "area"
-                                      ? "bg-orange-600 text-white hover:bg-orange-700"
-                                      : "bg-slate-700 text-slate-300 hover:bg-slate-600",
-                                  )}
-                                >
-                                  <Eraser className="w-5 h-5" />
-                                  <span className="text-sm">영역</span>
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => setEraserType((p) => (p === "stroke" ? "none" : "stroke"))}
-                                  className={cn(
-                                    "px-3 py-2.5 flex-1",
-                                    eraserType === "stroke"
-                                      ? "bg-red-600 text-white hover:bg-red-700"
-                                      : "bg-slate-700 text-slate-300 hover:bg-slate-600",
-                                  )}
-                                >
-                                  <Trash className="w-5 h-5" />
-                                  <span className="text-sm">획</span>
-                                </Button>
-                              </div>
-                            </div>
-
-                            {/* 지우개 크기 (영역 선택 시) */}
-                            {eraserType === "area" && (
-                              <div>
-                                <div className="text-xs font-semibold text-slate-400 mb-2">지우개 크기</div>
-                                <div className="flex items-center gap-2 bg-orange-700 rounded-lg px-3 py-2 w-fit">
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="p-1 h-auto w-auto hover:bg-orange-600 text-white rounded"
-                                    onClick={() => setEraserWidth((p) => Math.max(p - 2, 5))}
-                                  >
-                                    <Minus className="w-4 h-4" />
-                                  </Button>
-                                  <div className="text-white font-semibold min-w-7.5 text-center">{eraserWidth}</div>
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="p-1 h-auto w-auto hover:bg-orange-600 text-white rounded"
-                                    onClick={() => setEraserWidth((p) => Math.min(p + 2, 50))}
-                                  >
-                                    <PlusIcon className="w-4 h-4" />
-                                  </Button>
-                                </div>
-                              </div>
-                            )}
-
-                            {/* 실행취소/다시실행 */}
-                            <div>
-                              <div className="text-xs font-semibold text-slate-400 mb-2">실행취소</div>
-                              <div className="flex items-center gap-2">
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="bg-slate-700 hover:bg-slate-600 text-slate-300 flex-1"
-                                  onClick={() => drawingUndo()}
-                                >
-                                  <Undo className="w-5 h-5" />
-                                  <span className="text-sm">되돌리기</span>
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="bg-slate-700 hover:bg-slate-600 text-slate-300 flex-1"
-                                  onClick={() => drawingRedo()}
-                                >
-                                  <Redo className="w-5 h-5" />
-                                  <span className="text-sm">다시실행</span>
-                                </Button>
-                              </div>
-                            </div>
-                          </div>
-                        </PopoverContent>
-                      </Popover>
-
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="bg-slate-700 hover:bg-slate-600 text-slate-300 p-2.5"
-                        onClick={() => drawingUndo()}
-                      >
-                        <Undo className="w-5 h-5" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="bg-slate-700 hover:bg-slate-600 text-slate-300 p-2.5"
-                        onClick={() => drawingRedo()}
-                      >
-                        <Redo className="w-5 h-5" />
-                      </Button>
-                    </>
-                  )}
-                </div>
-
-                <div className="flex items-center gap-3">
-                  {currentSheet && (
-                    <Button
-                      size="sm"
-                      className="bg-amber-600 text-white hover:bg-amber-700 px-4 py-2.5 rounded-xl"
-                      onClick={handleSpotlightCall}
-                      title="현재 페이지를 다른 사용자에게 호출"
-                    >
-                      <Megaphone className="w-5 h-5" />
-                      <span className="text-sm">호출</span>
-                    </Button>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowCommandPanel(!showCommandPanel)}
-                    className={cn(
-                      "px-5 py-2.5 rounded-xl",
-                      showCommandPanel
-                        ? "bg-purple-600 text-white shadow-lg hover:bg-purple-700"
-                        : "bg-slate-700 text-slate-300 hover:bg-slate-600",
-                    )}
-                  >
-                    명령 패널
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
+          <DrawingToolbar
+            isCompact={isCompact}
+            tool={drawingTool}
+            actions={drawingActions}
+            hasSheet={!!currentSheet}
+            showCommandPanel={showCommandPanel}
+            penColors={penColors}
+            onToggleCommandPanel={handleToggleCommandPanel}
+            onSpotlightCall={handleSpotlightCall}
+          />
 
           {/* 악보 영역 */}
           <div
@@ -769,72 +403,23 @@ export default function Worship() {
 
             {/* 페이지 네비게이션 */}
             {sheets.length > 0 && (
-              <div
-                onClick={(e) => e.stopPropagation()}
-                className={cn(
-                  "absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-4 bg-slate-800/70 backdrop-blur-sm rounded-2xl px-6 py-4 shadow-2xl transition-opacity duration-300",
-                  showNavBar ? "opacity-100" : "opacity-0 pointer-events-none",
-                )}
-              >
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="bg-slate-700 hover:bg-slate-600 text-white"
-                  onClick={() => goToPageWithMotion(currentPage - 1)}
-                  disabled={currentPage <= 0}
-                >
-                  <ChevronLeft className="w-6 h-6" />
-                </Button>
-                <span className="text-white font-semibold text-lg min-w-25 text-center">
-                  {currentPage + 1} / {sheets.length}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="bg-slate-700 hover:bg-slate-600 text-white"
-                  onClick={() => goToPageWithMotion(currentPage + 1)}
-                  disabled={currentPage >= sheets.length - 1}
-                >
-                  <ChevronRight className="w-6 h-6" />
-                </Button>
-              </div>
+              <PageNavigator
+                visible={showNavBar}
+                currentPage={currentPage}
+                total={sheets.length}
+                onNavigate={goToPageWithMotion}
+              />
             )}
           </div>
         </main>
 
-        {/* 우측 명령 패널 */}
-        <motion.aside
-          aria-hidden={!showCommandPanel}
-          inert={!showCommandPanel}
-          initial={false}
-          animate={
-            showCommandPanel ? { width: commandPanelWidth, opacity: 1, x: 0 } : { width: "0rem", opacity: 0, x: 12 }
-          }
-          transition={shouldReduceMotion ? { duration: 0 } : panelTransition}
-          className={cn("shrink-0 bg-slate-800 overflow-hidden", showCommandPanel && "border-l border-slate-700")}
-          style={{ pointerEvents: showCommandPanel ? "auto" : "none" }}
-        >
-          <motion.div
-            animate={showCommandPanel ? { opacity: 1, x: 0 } : { opacity: 0, x: 8 }}
-            transition={shouldReduceMotion ? { duration: 0 } : panelContentTransition}
-            className="h-full overflow-y-auto p-4 box-border"
-            style={{ width: commandPanelWidth }}
-          >
-            <h2 className="text-lg font-bold text-white mb-4">명령 전송</h2>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-              {commands.map((command) => (
-                <button
-                  key={command.id}
-                  onClick={() => handleSendCommand(command)}
-                  className="flex flex-col items-center gap-2 p-6 bg-slate-700 hover:bg-slate-600 rounded-2xl transition-all active:scale-95 group"
-                >
-                  <span className="text-5xl group-hover:scale-110 transition-transform">{command.emoji}</span>
-                  <span className="text-sm font-semibold text-slate-300 text-center">{command.label}</span>
-                </button>
-              ))}
-            </div>
-          </motion.div>
-        </motion.aside>
+        <CommandPanel
+          show={showCommandPanel}
+          width={commandPanelWidth}
+          reducedMotion={!!shouldReduceMotion}
+          commands={commands}
+          onSendCommand={handleSendCommand}
+        />
       </div>
     </div>
   );

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -29,6 +29,7 @@ import { useWorship, useCommands, useSheetDrawings, useAdjacentDrawingsPreload }
 import { useAppStore } from "@/store/appStore";
 import { useWorshipSocket } from "@/hooks/useWorshipSocket";
 import { useWorshipRoom } from "@/hooks/useWorshipRoom";
+import { useWorshipPresence } from "@/hooks/useWorshipPresence";
 import SheetCanvas, { type EraserType, type RemoteInProgressPath } from "@/components/SheetCanvas";
 import { useDrawingSync, type DrawingPath } from "@/hooks/useDrawingSync";
 import { getSocket } from "@/hooks/useSocket";
@@ -61,14 +62,6 @@ const penColors = [
   { color: "bg-black", value: "#000000" },
 ];
 
-interface PresenceUser {
-  profileId: string;
-  name: string;
-  role: string;
-  roleIcon: string;
-  sheetId: string | null;
-}
-
 export default function Worship() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -89,7 +82,6 @@ export default function Worship() {
   const [showCommandPanel, setShowCommandPanel] = useState(false);
   const [presencePopoverOpen, setPresencePopoverOpen] = useState(false);
   const [isCompact, setIsCompact] = useState(false);
-  const [presenceUsers, setPresenceUsers] = useState<PresenceUser[]>([]);
   const [showNavBar, setShowNavBar] = useState(true);
   const navBarTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -120,8 +112,6 @@ export default function Worship() {
   // 페이지 뷰포트 ref (motion + gesture 컨테이너)
   const sheetViewportRef = useRef<HTMLDivElement>(null);
 
-  // spotlight toast가 stale callback을 잡지 않도록 ref로 우회
-  const commitSheetIdRef = useRef<(sheetId: string) => void>(() => {});
   const cancelPageMotionRef = useRef<() => void>(() => {});
 
   const socket = getSocket();
@@ -176,84 +166,6 @@ export default function Worship() {
     currentSheetId,
   });
 
-  // Socket: 접속자 현황 + 명령 + 스포트라이트
-  useEffect(() => {
-    const handlePresence = (data: { worshipId: string; users: PresenceUser[] }) => {
-      if (data.worshipId === id) {
-        // 중복 프로필 제거
-        const seen = new Set<string>();
-        const unique = data.users.filter((u) => {
-          if (seen.has(u.profileId)) return false;
-          seen.add(u.profileId);
-          return true;
-        });
-        setPresenceUsers(unique);
-      }
-    };
-
-    const handleCommand = (data: {
-      commandId: string;
-      emoji: string;
-      label: string;
-      senderName: string;
-      senderRole: string;
-      senderRoleIcon: string;
-    }) => {
-      const toastId = `command-${Date.now()}`;
-      toast.custom(
-        () => (
-          <div
-            className="bg-white rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-blue-500 cursor-pointer"
-            onClick={() => toast.dismiss(toastId)}
-          >
-            <div className="text-6xl">{data.emoji}</div>
-            <div className="flex-1">
-              <div className="text-2xl font-bold text-slate-800">{data.label}</div>
-              <div className="flex items-center gap-2 text-sm text-slate-500 mt-1">
-                <span className="text-lg">{data.senderRoleIcon}</span>
-                <span className="font-semibold">{data.senderName}</span>
-                <span>님이 전송</span>
-              </div>
-            </div>
-          </div>
-        ),
-        { duration: 3000, position: "top-center", id: toastId },
-      );
-    };
-
-    const handleSpotlight = (data: { sheetId: string; sheetTitle: string; senderName: string; senderRole: string }) => {
-      const toastId = `spotlight-${Date.now()}`;
-      toast.custom(
-        () => (
-          <div
-            className="bg-white rounded-2xl shadow-2xl p-6 flex items-center gap-4 min-w-87.5 border-4 border-amber-500 cursor-pointer active:bg-amber-50 transition-colors"
-            onClick={() => {
-              commitSheetIdRef.current(data.sheetId);
-              toast.dismiss(toastId);
-            }}
-          >
-            <div className="text-4xl">📢</div>
-            <div className="flex-1">
-              <div className="text-lg font-bold text-slate-800">{data.senderName}님이 호출합니다</div>
-              <div className="text-sm text-slate-500 mt-1">&quot;{data.sheetTitle}&quot;로 이동하려면 클릭하세요</div>
-            </div>
-          </div>
-        ),
-        { duration: 10000, position: "top-center", id: toastId },
-      );
-    };
-
-    socket.on("presence:update", handlePresence);
-    socket.on("command:received", handleCommand);
-    socket.on("page:spotlight", handleSpotlight);
-
-    return () => {
-      socket.off("presence:update", handlePresence);
-      socket.off("command:received", handleCommand);
-      socket.off("page:spotlight", handleSpotlight);
-    };
-  }, [id, socket]);
-
   // 네비게이션 바 자동 숨김 (5초)
   const flashNavBar = useCallback(() => {
     setShowNavBar(true);
@@ -297,7 +209,7 @@ export default function Worship() {
     [sheets, commitPage],
   );
 
-  commitSheetIdRef.current = commitSheetId;
+  const { presenceUsers } = useWorshipPresence({ worshipId: id, onSpotlightAccept: commitSheetId });
 
   useAdjacentSheetPreload(sheets, currentPage);
   useAdjacentDrawingsPreload(sheets, currentPage);

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -36,6 +36,7 @@ import { getSocket } from "@/hooks/useSocket";
 import { useAdjacentSheetPreload } from "@/hooks/useAdjacentSheetPreload";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useSheetPageMotion } from "@/hooks/useSheetPageMotion";
+import { useSheetZoomPan } from "@/hooks/useSheetZoomPan";
 
 const PANEL_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
 const panelTransition = { duration: 0.22, ease: PANEL_EASE };
@@ -85,34 +86,27 @@ export default function Worship() {
   const [showNavBar, setShowNavBar] = useState(true);
   const navBarTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 핀치줌 상태
-  const [scale, setScale] = useState(1);
-  const [translate, setTranslate] = useState({ x: 0, y: 0 });
-  const [transformOrigin, setTransformOrigin] = useState("center center");
+  // 핀치줌 중심점 기준이 되는 악보 카드 ref
   const sheetContainerRef = useRef<HTMLDivElement>(null);
-  const scaleRef = useRef(1);
-  scaleRef.current = scale;
-  const pinchRef = useRef<{
-    startDist: number;
-    startScale: number;
-    startCenter: { x: number; y: number };
-    startTranslate: { x: number; y: number };
-  } | null>(null);
-  const panRef = useRef<{
-    startX: number;
-    startY: number;
-    startTranslate: { x: number; y: number };
-  } | null>(null);
-  const lastTapRef = useRef(0);
+  // 페이지 뷰포트 ref (motion + gesture 컨테이너)
+  const sheetViewportRef = useRef<HTMLDivElement>(null);
+  const cancelPageMotionRef = useRef<() => void>(() => {});
+
+  // 핀치줌/팬 제스처
+  const {
+    scale,
+    translate,
+    transformOrigin,
+    handleSheetTouchStart,
+    handleSheetTouchMove,
+    handleSheetTouchEnd,
+    isZoomActive,
+    resetZoom,
+  } = useSheetZoomPan({ containerRef: sheetContainerRef, isDrawModeRef, cancelPageMotionRef });
 
   const sheets = useMemo(() => worshipData?.sheets || [], [worshipData?.sheets]);
   const currentSheet = sheets.find((s) => s.id === currentSheetId) || null;
   const currentPage = sheets.findIndex((s) => s.id === currentSheetId);
-
-  // 페이지 뷰포트 ref (motion + gesture 컨테이너)
-  const sheetViewportRef = useRef<HTMLDivElement>(null);
-
-  const cancelPageMotionRef = useRef<() => void>(() => {});
 
   const socket = getSocket();
 
@@ -122,9 +116,7 @@ export default function Worship() {
     if (currentSheetId && !updatedSheets.find((s) => s.id === currentSheetId)) {
       cancelPageMotionRef.current();
       setCurrentSheetId(updatedSheets[0]?.id || null);
-      setScale(1);
-      setTranslate({ x: 0, y: 0 });
-      setTransformOrigin("center center");
+      resetZoom();
     }
   });
 
@@ -192,13 +184,11 @@ export default function Worship() {
       if (index >= 0 && index < sheets.length) {
         cancelPageMotionRef.current();
         setCurrentSheetId(sheets[index].id);
-        setScale(1);
-        setTranslate({ x: 0, y: 0 });
-        setTransformOrigin("center center");
+        resetZoom();
         flashNavBar();
       }
     },
-    [sheets, flashNavBar],
+    [sheets, flashNavBar, resetZoom],
   );
 
   const commitSheetId = useCallback(
@@ -231,7 +221,7 @@ export default function Worship() {
     pageCount: sheets.length,
     containerRef: sheetViewportRef,
     enabled: !!currentSheet && !toolPopoverOpen,
-    isBlocked: () => isDrawModeRef.current || scaleRef.current > 1 || !!pinchRef.current || !!panRef.current,
+    isBlocked: () => isDrawModeRef.current || isZoomActive(),
     onCommitPage: commitPage,
     onDragStart: flashNavBar,
     reducedMotion: !!shouldReduceMotion,
@@ -242,130 +232,6 @@ export default function Worship() {
   // 전환 미리보기에 들어올 대상 시트의 stroke (프리페치돼 있으면 즉시 캐시 반환)
   const previewTargetSheet = activeTargetPage !== null ? sheets[activeTargetPage] : null;
   const { data: previewDrawings } = useSheetDrawings(previewTargetSheet?.id ?? null);
-
-  // 핀치줌 유틸
-  const parseOriginPercent = (origin: string): [number, number] => {
-    if (origin === "center center") return [50, 50];
-    const parts = origin.split(/\s+/);
-    return [parseFloat(parts[0]), parseFloat(parts[1])];
-  };
-
-  const getTouchDistance = (touches: React.TouchList) => {
-    const dx = touches[0].clientX - touches[1].clientX;
-    const dy = touches[0].clientY - touches[1].clientY;
-    return Math.sqrt(dx * dx + dy * dy);
-  };
-
-  const getTouchCenter = (touches: React.TouchList) => ({
-    x: (touches[0].clientX + touches[1].clientX) / 2,
-    y: (touches[0].clientY + touches[1].clientY) / 2,
-  });
-
-  // 핀치줌 핸들러 (악보 영역)
-  const handleSheetTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      if (e.touches.length === 2) {
-        // 진행 중인 page drag/animation 즉시 취소 (pinch 우선)
-        cancelPageMotion();
-        // 핀치 시작
-        const dist = getTouchDistance(e.touches);
-        const center = getTouchCenter(e.touches);
-        panRef.current = null;
-
-        // 핀치 중심점을 transformOrigin으로 설정
-        // scale > 1이면 origin 변경에 따른 translate 보정으로 위치 점프 방지
-        let currentTranslate = { ...translate };
-        const container = sheetContainerRef.current;
-        if (container) {
-          const rect = container.getBoundingClientRect();
-          const newRelX = ((center.x - rect.left) / rect.width) * 100;
-          const newRelY = ((center.y - rect.top) / rect.height) * 100;
-
-          if (scaleRef.current > 1) {
-            const [oldRelX, oldRelY] = parseOriginPercent(transformOrigin);
-            const s = scaleRef.current;
-            // rect는 렌더링 크기(CSS너비×scale)이므로 /s로 CSS 원본 너비 복원
-            const cssWidth = rect.width / s;
-            const cssHeight = rect.height / s;
-            currentTranslate = {
-              x: translate.x + ((oldRelX - newRelX) / 100) * cssWidth * (1 - s),
-              y: translate.y + ((oldRelY - newRelY) / 100) * cssHeight * (1 - s),
-            };
-            setTranslate(currentTranslate);
-          }
-
-          setTransformOrigin(`${newRelX}% ${newRelY}%`);
-        }
-
-        pinchRef.current = {
-          startDist: dist,
-          startScale: scaleRef.current,
-          startCenter: center,
-          startTranslate: currentTranslate,
-        };
-
-        e.preventDefault();
-      } else if (e.touches.length === 1) {
-        // 더블탭 감지
-        const now = Date.now();
-        if (now - lastTapRef.current < 300) {
-          setScale(1);
-          setTranslate({ x: 0, y: 0 });
-          setTransformOrigin("center center");
-          e.preventDefault();
-          lastTapRef.current = 0;
-          return;
-        }
-        lastTapRef.current = now;
-
-        // zoom > 1 + 보기모드 → 패닝 시작
-        if (scaleRef.current > 1 && !isDrawModeRef.current) {
-          panRef.current = {
-            startX: e.touches[0].clientX,
-            startY: e.touches[0].clientY,
-            startTranslate: { ...translate },
-          };
-        }
-      }
-    },
-    [translate, transformOrigin, cancelPageMotion],
-  );
-
-  const handleSheetTouchMove = useCallback((e: React.TouchEvent) => {
-    if (e.touches.length === 2 && pinchRef.current) {
-      const dist = getTouchDistance(e.touches);
-      const center = getTouchCenter(e.touches);
-      const newScale = Math.min(3, Math.max(1, pinchRef.current.startScale * (dist / pinchRef.current.startDist)));
-      const dx = center.x - pinchRef.current.startCenter.x;
-      const dy = center.y - pinchRef.current.startCenter.y;
-
-      if (newScale <= 1) {
-        setScale(1);
-        setTranslate({ x: 0, y: 0 });
-      } else {
-        setScale(newScale);
-        setTranslate({
-          x: pinchRef.current.startTranslate.x + dx,
-          y: pinchRef.current.startTranslate.y + dy,
-        });
-      }
-      e.preventDefault();
-    } else if (e.touches.length === 1 && panRef.current && scaleRef.current > 1) {
-      // 1-finger 패닝 (zoom > 1, 보기모드)
-      const dx = e.touches[0].clientX - panRef.current.startX;
-      const dy = e.touches[0].clientY - panRef.current.startY;
-      setTranslate({
-        x: panRef.current.startTranslate.x + dx,
-        y: panRef.current.startTranslate.y + dy,
-      });
-      e.preventDefault();
-    }
-  }, []);
-
-  const handleSheetTouchEnd = useCallback(() => {
-    pinchRef.current = null;
-    panRef.current = null;
-  }, []);
 
   const handleSendCommand = (command: { id: string; emoji: string; label: string }) => {
     if (!id || !currentProfileId) return;

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -28,9 +28,10 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useWorship, useCommands, useSheetDrawings, useAdjacentDrawingsPreload } from "@/hooks/queries";
 import { useAppStore } from "@/store/appStore";
 import { useWorshipSocket } from "@/hooks/useWorshipSocket";
+import { useWorshipRoom } from "@/hooks/useWorshipRoom";
 import SheetCanvas, { type EraserType, type RemoteInProgressPath } from "@/components/SheetCanvas";
 import { useDrawingSync, type DrawingPath } from "@/hooks/useDrawingSync";
-import { getSocket, setWorshipRoom } from "@/hooks/useSocket";
+import { getSocket } from "@/hooks/useSocket";
 import { useAdjacentSheetPreload } from "@/hooks/useAdjacentSheetPreload";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useSheetPageMotion } from "@/hooks/useSheetPageMotion";
@@ -169,37 +170,11 @@ export default function Worship() {
     }
   }, [worshipData, currentSheetId]);
 
-  // Socket: 예배 입장/퇴장
-  useEffect(() => {
-    if (!id || !currentProfileId) return;
-
-    socket.emit("join:worship", { worshipId: id, profileId: currentProfileId });
-    setWorshipRoom({ worshipId: id, profileId: currentProfileId });
-
-    return () => {
-      socket.emit("leave:worship", { worshipId: id });
-      setWorshipRoom(null);
-    };
-  }, [id, currentProfileId, socket]);
-
-  // Socket: 연결 상태 추적
-  const [isConnected, setIsConnected] = useState(socket.connected);
-  useEffect(() => {
-    const onDisconnect = () => setIsConnected(false);
-    const onConnect = () => setIsConnected(true);
-    socket.on("disconnect", onDisconnect);
-    socket.on("connect", onConnect);
-    return () => {
-      socket.off("disconnect", onDisconnect);
-      socket.off("connect", onConnect);
-    };
-  }, [socket]);
-
-  // Socket: 페이지 변경 알림
-  useEffect(() => {
-    if (!id || !currentSheetId) return;
-    socket.emit("page:change", { worshipId: id, sheetId: currentSheetId });
-  }, [id, currentSheetId, socket]);
+  const { isConnected } = useWorshipRoom({
+    worshipId: id,
+    profileId: currentProfileId,
+    currentSheetId,
+  });
 
   // Socket: 접속자 현황 + 명령 + 스포트라이트
   useEffect(() => {

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -28,8 +28,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useWorship, useCommands, useSheetDrawings, useAdjacentDrawingsPreload } from "@/hooks/queries";
 import { useAppStore } from "@/store/appStore";
 import { useWorshipSocket } from "@/hooks/useWorshipSocket";
-import SheetCanvas, { type EraserType } from "@/components/SheetCanvas";
-import { useDrawingSync } from "@/hooks/useDrawingSync";
+import SheetCanvas, { type EraserType, type RemoteInProgressPath } from "@/components/SheetCanvas";
+import { useDrawingSync, type DrawingPath } from "@/hooks/useDrawingSync";
 import { getSocket, setWorshipRoom } from "@/hooks/useSocket";
 import { useAdjacentSheetPreload } from "@/hooks/useAdjacentSheetPreload";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
@@ -46,6 +46,10 @@ const SHEET_CARD_SIZE_STYLE: CSSProperties = {
   aspectRatio: "3 / 4",
   height: "min(100cqh, calc(100cqw * 4 / 3))",
 };
+
+// preview SheetCanvas에 넘기는 빈 배열 — 매 렌더 새 배열 생성을 막아 불필요한 redraw 방지
+const EMPTY_PATHS: DrawingPath[] = [];
+const EMPTY_REMOTE: RemoteInProgressPath[] = [];
 
 const penColors = [
   { color: "bg-red-500", value: "#ef4444" },
@@ -1002,8 +1006,8 @@ export default function Worship() {
                     penWidth={penWidth}
                     eraserType="none"
                     eraserWidth={eraserWidth}
-                    paths={previewDrawings ?? []}
-                    remoteInProgress={[]}
+                    paths={previewDrawings ?? EMPTY_PATHS}
+                    remoteInProgress={EMPTY_REMOTE}
                     profileId={currentProfileId || ""}
                   />
                 </div>

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -259,7 +259,7 @@ export default function Worship() {
   );
 
   return (
-    <div className="h-dvh flex flex-col bg-slate-900">
+    <div className="h-dvh flex flex-col bg-viewer-bg">
       <WorshipHeader
         worshipTitle={worshipData?.title}
         worshipId={id}
@@ -292,7 +292,7 @@ export default function Worship() {
 
         {/* 중앙 악보 뷰어 */}
         <main
-          className="flex-1 flex flex-col bg-slate-900"
+          className="flex-1 flex flex-col bg-viewer-bg"
           style={isDrawMode ? { touchAction: "none", overscrollBehaviorX: "none" } : undefined}
         >
           <DrawingToolbar
@@ -366,10 +366,10 @@ export default function Worship() {
                     profileId={currentProfileId || ""}
                   />
                 ) : (
-                  <div className="w-full h-full flex items-center justify-center bg-slate-100">
+                  <div className="w-full h-full flex items-center justify-center bg-muted">
                     <div className="text-center">
-                      <Upload className="w-16 h-16 text-slate-400 mx-auto mb-4" />
-                      <p className="text-slate-500 text-lg">악보를 업로드하세요</p>
+                      <Upload className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
+                      <p className="text-muted-foreground text-lg">악보를 업로드하세요</p>
                     </div>
                   </div>
                 )}

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -46,6 +46,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 function SortableSheetItem({
@@ -77,19 +78,17 @@ function SortableSheetItem({
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Translate.toString(transform), transition }}
-      className={`bg-white rounded-xl p-4 border-2 transition-colors ${
-        isDragging
-          ? "opacity-30 border-dashed border-blue-300"
-          : "border-slate-200 hover:border-blue-300 hover:shadow-md"
+      className={`bg-card rounded-xl p-4 border-2 transition-colors ${
+        isDragging ? "opacity-30 border-dashed border-border" : "border-border hover:border-primary/40 hover:shadow-md"
       }`}
     >
       <div className="flex items-center gap-4">
         <div
           {...attributes}
           {...listeners}
-          className="cursor-grab active:cursor-grabbing p-2 hover:bg-slate-100 rounded-lg transition-colors touch-none"
+          className="cursor-grab active:cursor-grabbing min-h-11 min-w-11 flex items-center justify-center hover:bg-accent rounded-lg transition-colors touch-none"
         >
-          <GripVertical className="w-5 h-5 text-slate-400" />
+          <GripVertical className="w-5 h-5 text-muted-foreground" />
         </div>
 
         {/* 이미지 미리보기 */}
@@ -97,7 +96,7 @@ function SortableSheetItem({
           {sheet.imagePath ? (
             <Dialog>
               <DialogTrigger asChild>
-                <div className="relative w-20 h-24 rounded-lg overflow-hidden border-2 border-blue-300 cursor-pointer shadow-md">
+                <div className="relative w-20 h-24 rounded-lg overflow-hidden border-2 border-border cursor-pointer shadow-md">
                   <img src={`/uploads/${sheet.imagePath}`} alt={sheet.title} className="w-full h-full object-cover" />
                   <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/60 to-transparent p-2 flex items-center justify-center">
                     <Eye className="w-4 h-4 text-white" />
@@ -117,7 +116,7 @@ function SortableSheetItem({
               </DialogContent>
             </Dialog>
           ) : (
-            <div className="w-20 h-24 bg-linear-to-br from-amber-50 to-orange-100 rounded-lg flex items-center justify-center text-3xl border-2 border-slate-200">
+            <div className="w-20 h-24 bg-muted rounded-lg flex items-center justify-center text-3xl border-2 border-border">
               📄
             </div>
           )}
@@ -141,11 +140,11 @@ function SortableSheetItem({
                   }
                 }}
                 autoFocus
-                className="border-blue-500"
+                className="border-ring"
                 placeholder="악보 제목"
               />
               <div className="flex gap-2">
-                <Button size="sm" onClick={onSaveTitle} className="bg-green-600 hover:bg-green-700">
+                <Button size="sm" onClick={onSaveTitle}>
                   <Check className="w-3.5 h-3.5" />
                   저장
                 </Button>
@@ -158,28 +157,28 @@ function SortableSheetItem({
           ) : (
             <>
               <div className="flex items-center gap-2">
-                <div className="font-semibold text-slate-800 line-clamp-2">{sheet.title}</div>
+                <div className="font-semibold text-foreground line-clamp-2">{sheet.title}</div>
                 <Button
                   variant="ghost"
                   size="icon"
                   onClick={() => onEdit(sheet.id, sheet.title)}
                   title="제목 수정"
-                  className="p-1 h-auto w-auto text-blue-600 hover:bg-blue-100"
+                  className="min-h-11 min-w-11 text-primary hover:bg-accent"
                 >
                   <Pencil className="w-3.5 h-3.5" />
                 </Button>
               </div>
-              <div className="text-sm text-slate-500 mt-1 truncate">{sheet.fileName}</div>
+              <div className="text-sm text-muted-foreground mt-1 truncate">{sheet.fileName}</div>
             </>
           )}
         </div>
 
-        <div className="text-2xl font-bold text-slate-300 min-w-10 text-center">{index + 1}</div>
+        <div className="text-2xl font-bold text-muted-foreground min-w-10 text-center">{index + 1}</div>
 
         {!isEditing && (
           <ConfirmDialog
             trigger={
-              <Button variant="ghost" size="icon" className="text-red-500 hover:bg-red-50">
+              <Button variant="ghost" size="icon" className="text-destructive hover:bg-destructive/10">
                 <Trash2 className="w-5 h-5" />
               </Button>
             }
@@ -197,23 +196,23 @@ function SortableSheetItem({
 
 function SheetDragPreview({ sheet }: { sheet: Sheet }) {
   return (
-    <div className="bg-white rounded-xl p-4 border-2 border-blue-400 shadow-lg">
+    <div className="bg-card rounded-xl p-4 border-2 border-primary shadow-lg">
       <div className="flex items-center gap-4">
         <div className="p-2">
-          <GripVertical className="w-5 h-5 text-slate-400" />
+          <GripVertical className="w-5 h-5 text-muted-foreground" />
         </div>
         {sheet.imagePath ? (
-          <div className="w-20 h-24 rounded-lg overflow-hidden border-2 border-blue-300 shadow-md">
+          <div className="w-20 h-24 rounded-lg overflow-hidden border-2 border-border shadow-md">
             <img src={`/uploads/${sheet.imagePath}`} alt={sheet.title} className="w-full h-full object-cover" />
           </div>
         ) : (
-          <div className="w-20 h-24 bg-linear-to-br from-amber-50 to-orange-100 rounded-lg flex items-center justify-center text-3xl border-2 border-slate-200">
+          <div className="w-20 h-24 bg-muted rounded-lg flex items-center justify-center text-3xl border-2 border-border">
             📄
           </div>
         )}
         <div className="flex-1">
-          <div className="font-semibold text-slate-800 line-clamp-2">{sheet.title}</div>
-          <div className="text-sm text-slate-500 mt-1 truncate">{sheet.fileName}</div>
+          <div className="font-semibold text-foreground line-clamp-2">{sheet.title}</div>
+          <div className="text-sm text-muted-foreground mt-1 truncate">{sheet.fileName}</div>
         </div>
       </div>
     </div>
@@ -392,7 +391,7 @@ export default function WorshipEdit() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-5xl mx-auto">
         {/* 헤더 */}
         <div className="flex items-center gap-4 mb-8">
@@ -400,8 +399,8 @@ export default function WorshipEdit() {
             <ArrowLeft className="w-6 h-6" />
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">{isNew ? "새 예배 만들기" : "예배 편집"}</h1>
-            <p className="text-slate-600">예배 정보와 악보를 관리하세요</p>
+            <h1 className="text-3xl font-bold text-foreground">{isNew ? "새 예배 만들기" : "예배 편집"}</h1>
+            <p className="text-muted-foreground">예배 정보와 악보를 관리하세요</p>
           </div>
           <Button onClick={handleSave} disabled={saving}>
             <Save className="w-5 h-5" />
@@ -412,11 +411,11 @@ export default function WorshipEdit() {
         {/* 예배 정보 */}
         <Card className="mb-6">
           <CardContent>
-            <h2 className="text-xl font-bold text-slate-800 mb-6">예배 정보</h2>
+            <h2 className="text-xl font-bold text-foreground mb-6">예배 정보</h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <label className="block text-sm font-semibold text-slate-700 mb-2">
+                <label className="block text-sm font-semibold text-foreground mb-2">
                   <div className="flex items-center gap-2">
                     <FileText className="w-4 h-4" />
                     예배 제목 *
@@ -432,7 +431,7 @@ export default function WorshipEdit() {
               </div>
 
               <div>
-                <label className="block text-sm font-semibold text-slate-700 mb-2">
+                <label className="block text-sm font-semibold text-foreground mb-2">
                   <div className="flex items-center gap-2">
                     <Calendar className="w-4 h-4" />
                     예배 날짜 *
@@ -447,24 +446,27 @@ export default function WorshipEdit() {
               </div>
 
               <div>
-                <label className="block text-sm font-semibold text-slate-700 mb-2">
+                <label className="block text-sm font-semibold text-foreground mb-2">
                   <div className="flex items-center gap-2">
                     <Tag className="w-4 h-4" />
                     예배 유형 *
                   </div>
                 </label>
                 {worshipTypes.length > 0 ? (
-                  <select
-                    value={typeId}
-                    onChange={(e) => setTypeId(e.target.value)}
-                    className="w-full px-5 py-4 bg-slate-50 border-2 border-slate-200 rounded-xl focus:border-blue-500 focus:outline-none text-lg transition-colors"
-                  >
-                    {worshipTypes.map((type) => (
-                      <option key={type.id} value={type.id}>
-                        {type.name}
-                      </option>
-                    ))}
-                  </select>
+                  <Select value={typeId} onValueChange={setTypeId}>
+                    <SelectTrigger className="w-full data-[size=default]:h-14 text-lg bg-background">
+                      <SelectValue placeholder="예배 유형 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {worshipTypes.map((type) => (
+                          <SelectItem key={type.id} value={type.id}>
+                            {type.name}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
                 ) : (
                   <div className="w-full px-5 py-4 bg-yellow-50 border-2 border-yellow-200 rounded-xl text-yellow-800">
                     <div className="flex items-center gap-2 mb-2">
@@ -490,10 +492,12 @@ export default function WorshipEdit() {
           <CardContent>
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="text-xl font-bold text-slate-800">악보 관리</h2>
-                <p className="text-sm text-slate-500 mt-1">드래그하여 순서를 변경하거나 제목을 수정할 수 있습니다</p>
+                <h2 className="text-xl font-bold text-foreground">악보 관리</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  드래그하여 순서를 변경하거나 제목을 수정할 수 있습니다
+                </p>
               </div>
-              <Button onClick={() => fileInputRef.current?.click()} className="bg-green-600 hover:bg-green-700">
+              <Button onClick={() => fileInputRef.current?.click()}>
                 <Upload className="w-5 h-5" />
                 악보 추가
               </Button>
@@ -508,12 +512,12 @@ export default function WorshipEdit() {
             </div>
 
             {/* 업로드 안내 */}
-            <div className="mb-6 p-4 bg-blue-50 border-2 border-blue-200 rounded-xl">
+            <div className="mb-6 p-4 bg-accent border-2 border-border rounded-xl">
               <div className="flex items-start gap-3">
-                <ImageIcon className="w-5 h-5 text-blue-600 mt-0.5" />
-                <div className="flex-1 text-sm text-blue-800">
+                <ImageIcon className="w-5 h-5 text-primary mt-0.5" />
+                <div className="flex-1 text-sm text-accent-foreground">
                   <div className="font-semibold mb-1">악보 업로드 안내</div>
-                  <ul className="space-y-1 text-blue-700">
+                  <ul className="space-y-1 text-accent-foreground">
                     <li>JPG, PNG, HEIC 이미지 파일을 지원합니다</li>
                     <li>여러 파일을 한 번에 선택하여 업로드할 수 있습니다</li>
                     <li>드래그하여 악보 순서를 자유롭게 변경하세요</li>
@@ -555,12 +559,12 @@ export default function WorshipEdit() {
                 </DragOverlay>
               </DndContext>
             ) : (
-              <div className="text-center py-16 bg-slate-50 rounded-xl border-2 border-dashed border-slate-300">
-                <div className="w-16 h-16 bg-slate-200 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <Upload className="w-8 h-8 text-slate-400" />
+              <div className="text-center py-16 bg-muted rounded-xl border-2 border-dashed border-border">
+                <div className="w-16 h-16 bg-secondary rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <Upload className="w-8 h-8 text-muted-foreground" />
                 </div>
-                <h3 className="text-lg font-semibold text-slate-700 mb-2">아직 악보가 없습니다</h3>
-                <p className="text-slate-500 mb-6">악보 추가 버튼을 눌러 이미지를 업로드하세요</p>
+                <h3 className="text-lg font-semibold text-foreground mb-2">아직 악보가 없습니다</h3>
+                <p className="text-muted-foreground mb-6">악보 추가 버튼을 눌러 이미지를 업로드하세요</p>
                 <Button onClick={() => fileInputRef.current?.click()}>
                   <Upload className="w-5 h-5" />
                   악보 추가
@@ -572,22 +576,22 @@ export default function WorshipEdit() {
 
         {/* 통계 카드 */}
         <div className="grid grid-cols-3 gap-4">
-          <Card className="bg-linear-to-br from-blue-50 to-blue-100 border-2 border-blue-200 shadow-none">
+          <Card className="bg-accent shadow-none">
             <CardContent>
-              <div className="text-sm font-semibold text-blue-700 mb-1">총 악보</div>
-              <div className="text-3xl font-bold text-blue-900">{sheets.length}개</div>
+              <div className="text-sm font-semibold text-accent-foreground mb-1">총 악보</div>
+              <div className="text-3xl font-bold text-primary">{sheets.length}개</div>
             </CardContent>
           </Card>
-          <Card className="bg-linear-to-br from-green-50 to-green-100 border-2 border-green-200 shadow-none">
+          <Card className="bg-accent shadow-none">
             <CardContent>
-              <div className="text-sm font-semibold text-green-700 mb-1">예배 날짜</div>
-              <div className="text-xl font-bold text-green-900">{date || "미정"}</div>
+              <div className="text-sm font-semibold text-accent-foreground mb-1">예배 날짜</div>
+              <div className="text-xl font-bold text-primary">{date || "미정"}</div>
             </CardContent>
           </Card>
-          <Card className="bg-linear-to-br from-purple-50 to-purple-100 border-2 border-purple-200 shadow-none">
+          <Card className="bg-accent shadow-none">
             <CardContent>
-              <div className="text-sm font-semibold text-purple-700 mb-1">상태</div>
-              <div className="text-xl font-bold text-purple-900">
+              <div className="text-sm font-semibold text-accent-foreground mb-1">상태</div>
+              <div className="text-xl font-bold text-primary">
                 {title && date && sheets.length > 0 ? "준비완료" : "작성중"}
               </div>
             </CardContent>

--- a/client/src/pages/WorshipList.tsx
+++ b/client/src/pages/WorshipList.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 export default function WorshipList() {
@@ -107,7 +108,7 @@ export default function WorshipList() {
   const hasActiveFilter = !!(debouncedQuery || selectedTypeId || selectedYear);
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-5xl mx-auto">
         {/* 헤더 */}
         <div className="flex items-center gap-4 mb-8">
@@ -117,19 +118,19 @@ export default function WorshipList() {
             </Link>
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">예배 목록</h1>
-            <p className="text-slate-600">예배를 선택하거나 새로운 예배를 만드세요</p>
+            <h1 className="text-3xl font-bold text-foreground">예배 목록</h1>
+            <p className="text-muted-foreground">예배를 선택하거나 새로운 예배를 만드세요</p>
           </div>
           {currentProfile && (
-            <div className="flex items-center gap-3 px-5 py-3 bg-white rounded-xl shadow-md border-2 border-slate-200">
+            <div className="flex items-center gap-3 px-5 py-3 bg-card rounded-xl shadow-sm border-2 border-border">
               <div
                 className={`w-10 h-10 ${currentProfile.color} rounded-full flex items-center justify-center text-xl`}
               >
                 {currentRole?.icon}
               </div>
               <div>
-                <div className="text-sm font-semibold text-slate-800">{currentProfile.name}</div>
-                <div className="text-xs text-slate-500">{currentRole?.name}</div>
+                <div className="text-sm font-semibold text-foreground">{currentProfile.name}</div>
+                <div className="text-xs text-muted-foreground">{currentRole?.name}</div>
               </div>
             </div>
           )}
@@ -144,8 +145,8 @@ export default function WorshipList() {
         <Card className="mb-6 p-6">
           <CardContent className="p-0">
             <div className="flex items-center gap-4 mb-4">
-              <Filter className="w-5 h-5 text-slate-600" />
-              <h3 className="font-bold text-slate-800">필터</h3>
+              <Filter className="w-5 h-5 text-muted-foreground" />
+              <h3 className="font-bold text-foreground">필터</h3>
             </div>
 
             {/* 검색 */}
@@ -157,26 +158,25 @@ export default function WorshipList() {
                 className="pl-12"
                 placeholder="예배 이름 검색..."
               />
-              <Music className="absolute top-1/2 -translate-y-1/2 left-4 w-5 h-5 text-slate-400" />
+              <Music className="absolute top-1/2 -translate-y-1/2 left-4 w-5 h-5 text-muted-foreground" />
               {searchQuery && (
                 <button
-                  className="absolute top-1/2 -translate-y-1/2 right-3 p-1 hover:bg-slate-200 rounded-full transition-colors"
+                  className="absolute top-1/2 -translate-y-1/2 right-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-secondary rounded-full transition-colors"
                   onClick={() => setSearchQuery("")}
                 >
-                  <X className="w-5 h-5 text-slate-500" />
+                  <X className="w-5 h-5 text-muted-foreground" />
                 </button>
               )}
             </div>
 
             {/* 예배 유형 필터 */}
             <div className="mb-4">
-              <label className="block text-sm font-semibold text-slate-700 mb-2">예배 유형</label>
+              <label className="block text-sm font-semibold text-foreground mb-2">예배 유형</label>
               <div className="flex flex-wrap gap-2">
                 <Button
                   variant={!selectedTypeId ? "default" : "secondary"}
                   size="sm"
                   onClick={() => setSelectedTypeId("")}
-                  className={!selectedTypeId ? "bg-slate-800 hover:bg-slate-900" : ""}
                 >
                   전체
                 </Button>
@@ -204,46 +204,59 @@ export default function WorshipList() {
 
             {/* 날짜 필터 */}
             <div>
-              <label className="block text-sm font-semibold text-slate-700 mb-2">날짜</label>
+              <label className="block text-sm font-semibold text-foreground mb-2">날짜</label>
               <div className="flex items-center gap-3">
-                <select
-                  value={selectedYear}
-                  onChange={(e) => {
-                    setSelectedYear(e.target.value);
-                    if (!e.target.value) setSelectedMonth("");
+                <Select
+                  value={selectedYear || "all"}
+                  onValueChange={(v) => {
+                    const year = v === "all" ? "" : v;
+                    setSelectedYear(year);
+                    if (!year) setSelectedMonth("");
                   }}
-                  className="px-4 py-2 bg-slate-50 border-2 border-slate-200 rounded-xl focus:border-blue-500 focus:outline-none text-sm transition-colors"
                 >
-                  <option value="">전체 연도</option>
-                  {availableYears.map((year) => (
-                    <option key={year} value={year}>
-                      {year}년
-                    </option>
-                  ))}
-                </select>
-                <select
-                  value={selectedMonth}
-                  onChange={(e) => setSelectedMonth(e.target.value)}
+                  <SelectTrigger className="min-w-32 text-base bg-background">
+                    <SelectValue placeholder="전체 연도" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value="all">전체 연도</SelectItem>
+                      {availableYears.map((year) => (
+                        <SelectItem key={year} value={String(year)}>
+                          {year}년
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={selectedMonth || "all"}
+                  onValueChange={(v) => setSelectedMonth(v === "all" ? "" : v)}
                   disabled={!selectedYear}
-                  className="px-4 py-2 bg-slate-50 border-2 border-slate-200 rounded-xl focus:border-blue-500 focus:outline-none text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  <option value="">전체 월</option>
-                  {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
-                    <option key={month} value={month}>
-                      {month}월
-                    </option>
-                  ))}
-                </select>
+                  <SelectTrigger className="min-w-28 text-base bg-background">
+                    <SelectValue placeholder="전체 월" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value="all">전체 월</SelectItem>
+                      {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                        <SelectItem key={month} value={String(month)}>
+                          {month}월
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
                 {(selectedYear || selectedMonth) && (
                   <button
                     onClick={() => {
                       setSelectedYear("");
                       setSelectedMonth("");
                     }}
-                    className="p-2 hover:bg-slate-200 rounded-full transition-colors"
+                    className="min-h-11 min-w-11 flex items-center justify-center hover:bg-secondary rounded-full transition-colors"
                     title="날짜 필터 초기화"
                   >
-                    <X className="w-4 h-4 text-slate-500" />
+                    <X className="w-4 h-4 text-muted-foreground" />
                   </button>
                 )}
               </div>
@@ -258,19 +271,19 @@ export default function WorshipList() {
             return (
               <Card
                 key={worship.id}
-                className="p-6 border-2 border-transparent hover:border-blue-200 transition-all hover:shadow-xl"
+                className="p-6 border-2 border-transparent hover:border-primary/40 transition-all hover:shadow-md"
               >
                 <CardContent className="p-0">
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="mb-3">
-                        <h3 className="text-xl font-bold text-slate-800">{worship.title}</h3>
+                        <h3 className="text-xl font-bold text-foreground">{worship.title}</h3>
                         <div className="flex items-center gap-3 mt-2">
-                          <div className="flex items-center gap-1 text-sm text-slate-500">
+                          <div className="flex items-center gap-1 text-sm text-muted-foreground">
                             <Calendar className="w-4 h-4" />
                             {formatDate(worship.date)}
                           </div>
-                          <div className="text-sm text-slate-500">악보 {worship.sheets?.length ?? 0}개</div>
+                          <div className="text-sm text-muted-foreground">악보 {worship.sheets?.length ?? 0}개</div>
                           {worshipType && (
                             <Badge
                               variant="secondary"
@@ -281,11 +294,13 @@ export default function WorshipList() {
                           )}
                         </div>
                       </div>
-                      <div className="text-sm text-slate-400">마지막 수정: {formatLastEdited(worship.updatedAt)}</div>
+                      <div className="text-sm text-muted-foreground">
+                        마지막 수정: {formatLastEdited(worship.updatedAt)}
+                      </div>
                     </div>
 
                     <div className="flex items-center gap-2">
-                      <Button asChild className="bg-green-600 hover:bg-green-700">
+                      <Button asChild>
                         <Link to={`/worship/${worship.id}`}>
                           <Play className="w-5 h-5" />
                           시작
@@ -323,23 +338,23 @@ export default function WorshipList() {
 
           {/* 무한 스크롤 sentinel + 로딩 표시 */}
           <div ref={sentinelRef} className="h-4" />
-          {isFetchingNextPage && <div className="text-center py-4 text-slate-500 text-sm">불러오는 중...</div>}
+          {isFetchingNextPage && <div className="text-center py-4 text-muted-foreground text-sm">불러오는 중...</div>}
         </div>
 
         {/* 첫 로딩 */}
-        {isLoading && <div className="text-center py-12 text-slate-500">불러오는 중...</div>}
+        {isLoading && <div className="text-center py-12 text-muted-foreground">불러오는 중...</div>}
 
         {/* 빈 상태 */}
         {!isLoading && worships.length === 0 && (
           <Card className="p-16 text-center rounded-3xl">
             <CardContent className="p-0">
-              <div className="w-24 h-24 bg-slate-100 rounded-3xl flex items-center justify-center mx-auto mb-6">
-                <Music className="w-12 h-12 text-slate-400" />
+              <div className="w-24 h-24 bg-muted rounded-3xl flex items-center justify-center mx-auto mb-6">
+                <Music className="w-12 h-12 text-muted-foreground" />
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 mb-2">
+              <h3 className="text-2xl font-bold text-foreground mb-2">
                 {hasActiveFilter ? "검색 결과가 없습니다" : "아직 예배가 없습니다"}
               </h3>
-              <p className="text-slate-600 mb-8">
+              <p className="text-muted-foreground mb-8">
                 {hasActiveFilter ? "다른 검색어나 필터를 시도해보세요" : "새 예배를 만들어 악보를 추가하세요"}
               </p>
               {!hasActiveFilter && (
@@ -356,22 +371,22 @@ export default function WorshipList() {
         {/* 통계 */}
         {total > 0 && (
           <div className="mt-6 grid grid-cols-3 gap-4">
-            <Card className="bg-linear-to-br from-blue-50 to-blue-100 border-2 border-blue-200 p-6">
+            <Card className="bg-accent p-6">
               <CardContent className="p-0">
-                <div className="text-sm font-semibold text-blue-700 mb-1">전체 예배</div>
-                <div className="text-3xl font-bold text-blue-900">{total}개</div>
+                <div className="text-sm font-semibold text-accent-foreground mb-1">전체 예배</div>
+                <div className="text-3xl font-bold text-primary">{total}개</div>
               </CardContent>
             </Card>
-            <Card className="bg-linear-to-br from-green-50 to-green-100 border-2 border-green-200 p-6">
+            <Card className="bg-accent p-6">
               <CardContent className="p-0">
-                <div className="text-sm font-semibold text-green-700 mb-1">불러온 예배</div>
-                <div className="text-3xl font-bold text-green-900">{worships.length}개</div>
+                <div className="text-sm font-semibold text-accent-foreground mb-1">불러온 예배</div>
+                <div className="text-3xl font-bold text-primary">{worships.length}개</div>
               </CardContent>
             </Card>
-            <Card className="bg-linear-to-br from-purple-50 to-purple-100 border-2 border-purple-200 p-6">
+            <Card className="bg-accent p-6">
               <CardContent className="p-0">
-                <div className="text-sm font-semibold text-purple-700 mb-1">예배 유형</div>
-                <div className="text-3xl font-bold text-purple-900">{worshipTypes.length}개</div>
+                <div className="text-sm font-semibold text-accent-foreground mb-1">예배 유형</div>
+                <div className="text-3xl font-bold text-primary">{worshipTypes.length}개</div>
               </CardContent>
             </Card>
           </div>

--- a/client/src/pages/WorshipList.tsx
+++ b/client/src/pages/WorshipList.tsx
@@ -1,7 +1,14 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import { Plus, Calendar, Music, Edit, Trash2, Play, ArrowLeft, Filter, X } from "lucide-react";
-import { useWorships, useWorshipTypes, useDeleteWorship, useProfiles, useRoles } from "@/hooks/queries";
+import {
+  useWorships,
+  useWorshipYears,
+  useWorshipTypes,
+  useDeleteWorship,
+  useProfiles,
+  useRoles,
+} from "@/hooks/queries";
 import { useAppStore } from "@/store/appStore";
 import { getColorOption } from "@/lib/colors";
 import { Button } from "@/components/ui/button";
@@ -11,18 +18,36 @@ import { Badge } from "@/components/ui/badge";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 export default function WorshipList() {
-  const { data: worships = [] } = useWorships();
   const { data: worshipTypes = [] } = useWorshipTypes();
   const { data: profiles = [] } = useProfiles();
   const { data: roles = [] } = useRoles();
+  const { data: availableYears = [] } = useWorshipYears();
   const deleteWorshipMutation = useDeleteWorship();
   const currentProfileId = useAppStore((s) => s.currentProfileId);
   const navigate = useNavigate();
 
   const [selectedTypeId, setSelectedTypeId] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const [selectedYear, setSelectedYear] = useState<string>("");
   const [selectedMonth, setSelectedMonth] = useState<string>("");
+
+  // 검색어 디바운스 (서버 호출이므로 매 타이핑마다 요청하지 않도록)
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // 무한 스크롤 목록 (서버 페이지네이션 + 날짜 최신순 정렬, 필터는 서버에서 처리)
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useWorships({
+    typeId: selectedTypeId,
+    q: debouncedQuery,
+    year: selectedYear,
+    month: selectedMonth,
+  });
+
+  const worships = data?.pages.flatMap((p) => p.items) ?? [];
+  const total = data?.pages[0]?.total ?? 0;
 
   // 프로필 미선택 시 홈으로 리다이렉트
   useEffect(() => {
@@ -36,38 +61,30 @@ export default function WorshipList() {
     navigator.storage?.persist?.();
   }, []);
 
-  // 악보 이미지 백그라운드 프리로드 (최신 예배 우선)
+  // 필터 변경 시 스크롤 최상단 리셋 (queryKey 변경으로 page 1부터 재조회됨)
   useEffect(() => {
-    if (!worships.length) return;
-    const sorted = [...worships].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-    for (const worship of sorted) {
-      for (const sheet of worship.sheets || []) {
-        if (sheet.imagePath) {
-          const img = new Image();
-          img.src = `/uploads/${sheet.imagePath}`;
+    window.scrollTo({ top: 0 });
+  }, [selectedTypeId, debouncedQuery, selectedYear, selectedMonth]);
+
+  // 무한 스크롤 sentinel — 목록 끝이 보이면 다음 페이지 로드
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
         }
-      }
-    }
-  }, [worships]);
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const currentProfile = profiles.find((p) => p.id === currentProfileId);
   const currentRole = currentProfile ? roles.find((r) => r.id === currentProfile.roleId) : undefined;
-
-  // 데이터에서 연도 목록 추출
-  const availableYears = [...new Set(worships.map((w) => new Date(w.date).getFullYear()))].sort((a, b) => b - a);
-
-  const filteredWorships = worships.filter((worship) => {
-    const matchesType = !selectedTypeId || worship.typeId === selectedTypeId;
-    const matchesSearch = worship.title.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesDate = (() => {
-      if (!selectedYear) return true;
-      const worshipDate = new Date(worship.date);
-      if (worshipDate.getFullYear() !== parseInt(selectedYear)) return false;
-      if (selectedMonth && worshipDate.getMonth() + 1 !== parseInt(selectedMonth)) return false;
-      return true;
-    })();
-    return matchesType && matchesSearch && matchesDate;
-  });
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -86,6 +103,8 @@ export default function WorshipList() {
   const handleDelete = async (id: string) => {
     await deleteWorshipMutation.mutateAsync(id);
   };
+
+  const hasActiveFilter = !!(debouncedQuery || selectedTypeId || selectedYear);
 
   return (
     <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
@@ -234,7 +253,7 @@ export default function WorshipList() {
 
         {/* 예배 목록 */}
         <div className="space-y-4">
-          {filteredWorships.map((worship) => {
+          {worships.map((worship) => {
             const worshipType = worshipTypes.find((t) => t.id === worship.typeId);
             return (
               <Card
@@ -301,24 +320,29 @@ export default function WorshipList() {
               </Card>
             );
           })}
+
+          {/* 무한 스크롤 sentinel + 로딩 표시 */}
+          <div ref={sentinelRef} className="h-4" />
+          {isFetchingNextPage && <div className="text-center py-4 text-slate-500 text-sm">불러오는 중...</div>}
         </div>
 
+        {/* 첫 로딩 */}
+        {isLoading && <div className="text-center py-12 text-slate-500">불러오는 중...</div>}
+
         {/* 빈 상태 */}
-        {filteredWorships.length === 0 && (
+        {!isLoading && worships.length === 0 && (
           <Card className="p-16 text-center rounded-3xl">
             <CardContent className="p-0">
               <div className="w-24 h-24 bg-slate-100 rounded-3xl flex items-center justify-center mx-auto mb-6">
                 <Music className="w-12 h-12 text-slate-400" />
               </div>
               <h3 className="text-2xl font-bold text-slate-800 mb-2">
-                {searchQuery || selectedTypeId || selectedYear ? "검색 결과가 없습니다" : "아직 예배가 없습니다"}
+                {hasActiveFilter ? "검색 결과가 없습니다" : "아직 예배가 없습니다"}
               </h3>
               <p className="text-slate-600 mb-8">
-                {searchQuery || selectedTypeId || selectedYear
-                  ? "다른 검색어나 필터를 시도해보세요"
-                  : "새 예배를 만들어 악보를 추가하세요"}
+                {hasActiveFilter ? "다른 검색어나 필터를 시도해보세요" : "새 예배를 만들어 악보를 추가하세요"}
               </p>
-              {!searchQuery && !selectedTypeId && !selectedYear && (
+              {!hasActiveFilter && (
                 <Button size="lg" asChild>
                   <Link to="/worship-edit/new">
                     <Plus className="w-5 h-5" />새 예배 만들기
@@ -330,18 +354,18 @@ export default function WorshipList() {
         )}
 
         {/* 통계 */}
-        {worships.length > 0 && (
+        {total > 0 && (
           <div className="mt-6 grid grid-cols-3 gap-4">
             <Card className="bg-linear-to-br from-blue-50 to-blue-100 border-2 border-blue-200 p-6">
               <CardContent className="p-0">
                 <div className="text-sm font-semibold text-blue-700 mb-1">전체 예배</div>
-                <div className="text-3xl font-bold text-blue-900">{worships.length}개</div>
+                <div className="text-3xl font-bold text-blue-900">{total}개</div>
               </CardContent>
             </Card>
             <Card className="bg-linear-to-br from-green-50 to-green-100 border-2 border-green-200 p-6">
               <CardContent className="p-0">
-                <div className="text-sm font-semibold text-green-700 mb-1">필터링된 예배</div>
-                <div className="text-3xl font-bold text-green-900">{filteredWorships.length}개</div>
+                <div className="text-sm font-semibold text-green-700 mb-1">불러온 예배</div>
+                <div className="text-3xl font-bold text-green-900">{worships.length}개</div>
               </CardContent>
             </Card>
             <Card className="bg-linear-to-br from-purple-50 to-purple-100 border-2 border-purple-200 p-6">

--- a/client/src/pages/WorshipTypeSettings.tsx
+++ b/client/src/pages/WorshipTypeSettings.tsx
@@ -57,7 +57,7 @@ export default function WorshipTypeSettings() {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-slate-50 to-slate-100 p-8">
+    <div className="min-h-screen bg-background p-8">
       <div className="max-w-5xl mx-auto">
         <div className="flex items-center gap-4 mb-8">
           <Button variant="outline" size="icon" asChild>
@@ -66,8 +66,8 @@ export default function WorshipTypeSettings() {
             </Link>
           </Button>
           <div className="flex-1">
-            <h1 className="text-3xl font-bold text-slate-800">예배 유형 관리</h1>
-            <p className="text-slate-600">예배 유형을 추가하고 관리하세요</p>
+            <h1 className="text-3xl font-bold text-foreground">예배 유형 관리</h1>
+            <p className="text-muted-foreground">예배 유형을 추가하고 관리하세요</p>
           </div>
           {!isEditing && (
             <Button onClick={handleAdd}>
@@ -78,14 +78,14 @@ export default function WorshipTypeSettings() {
 
         {/* 편집 폼 */}
         {isEditing && (
-          <Card className="mb-6 border-2 border-blue-200">
+          <Card className="mb-6 border-2 border-primary/40">
             <CardContent>
-              <h2 className="text-xl font-bold text-slate-800 mb-6">
+              <h2 className="text-xl font-bold text-foreground mb-6">
                 {editingTypeId ? "예배 유형 수정" : "새 예배 유형 추가"}
               </h2>
               <div className="space-y-6">
                 <div>
-                  <label className="block text-sm font-semibold text-slate-700 mb-2">예배 유형 이름 *</label>
+                  <label className="block text-sm font-semibold text-foreground mb-2">예배 유형 이름 *</label>
                   <Input
                     type="text"
                     value={formData.name}
@@ -95,7 +95,7 @@ export default function WorshipTypeSettings() {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-semibold text-slate-700 mb-2">색상 선택</label>
+                  <label className="block text-sm font-semibold text-foreground mb-2">색상 선택</label>
                   <div className="grid grid-cols-5 md:grid-cols-10 gap-3">
                     {COLOR_OPTIONS.map((c) => (
                       <button
@@ -112,7 +112,7 @@ export default function WorshipTypeSettings() {
                   </div>
                 </div>
                 <div>
-                  <label className="block text-sm font-semibold text-slate-700 mb-2">미리보기</label>
+                  <label className="block text-sm font-semibold text-foreground mb-2">미리보기</label>
                   <span
                     className={`inline-block px-4 py-2 rounded-full font-semibold text-white ${getColorOption(formData.color)?.bg || "bg-blue-500"}`}
                   >
@@ -137,13 +137,13 @@ export default function WorshipTypeSettings() {
         {/* 유형 목록 */}
         <Card>
           <CardContent>
-            <h2 className="text-xl font-bold text-slate-800 mb-6">현재 예배 유형 ({worshipTypes.length}개)</h2>
+            <h2 className="text-xl font-bold text-foreground mb-6">현재 예배 유형 ({worshipTypes.length}개)</h2>
             {worshipTypes.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {worshipTypes.map((type) => (
                   <div
                     key={type.id}
-                    className="bg-gradient-to-r from-slate-50 to-slate-100 rounded-xl p-5 border-2 border-slate-200 hover:border-blue-300 transition-all"
+                    className="bg-muted rounded-xl p-5 border-2 border-border hover:border-primary/40 transition-all"
                   >
                     <div className="flex items-center justify-between">
                       <span
@@ -173,12 +173,12 @@ export default function WorshipTypeSettings() {
                 ))}
               </div>
             ) : (
-              <div className="text-center py-16 bg-slate-50 rounded-xl border-2 border-dashed border-slate-300">
-                <div className="w-16 h-16 bg-slate-200 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <Tag className="w-8 h-8 text-slate-400" />
+              <div className="text-center py-16 bg-muted rounded-xl border-2 border-dashed border-border">
+                <div className="w-16 h-16 bg-secondary rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <Tag className="w-8 h-8 text-muted-foreground" />
                 </div>
-                <h3 className="text-lg font-semibold text-slate-700 mb-2">아직 예배 유형이 없습니다</h3>
-                <p className="text-slate-500 mb-6">새 유형 추가 버튼을 눌러 예배 유형을 만드세요</p>
+                <h3 className="text-lg font-semibold text-foreground mb-2">아직 예배 유형이 없습니다</h3>
+                <p className="text-muted-foreground mb-6">새 유형 추가 버튼을 눌러 예배 유형을 만드세요</p>
                 <Button onClick={handleAdd}>
                   <Plus className="w-5 h-5" />새 유형 추가
                 </Button>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -43,3 +43,11 @@ export interface Command {
   label: string;
   isDefault: boolean;
 }
+
+export interface PresenceUser {
+  profileId: string;
+  name: string;
+  role: string;
+  roleIcon: string;
+  sheetId: string | null;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -37,6 +37,14 @@ export interface Worship {
   sheets: Sheet[];
 }
 
+export interface WorshipPage {
+  items: Worship[];
+  total: number;
+  page: number;
+  hasMore: boolean;
+  nextPage: number | null;
+}
+
 export interface Command {
   id: string;
   emoji: string;

--- a/server/routes/worships.ts
+++ b/server/routes/worships.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { nanoid } from "nanoid";
-import { eq } from "drizzle-orm";
+import { eq, and, like, desc, inArray, sql } from "drizzle-orm";
 import fs from "fs";
 import path from "path";
 import { db } from "../db";
@@ -9,22 +9,88 @@ import { config } from "../config.js";
 
 const router = Router();
 
-router.get("/", (_req, res) => {
+router.get("/", (req, res) => {
   try {
-    const allWorships = db.select().from(worships).all();
-    const result = allWorships.map((w) => {
-      const worshipSheets = db
-        .select()
-        .from(sheets)
-        .where(eq(sheets.worshipId, w.id))
-        .all()
-        .sort((a, b) => a.order - b.order);
-      return { ...w, sheets: worshipSheets };
-    });
-    res.json(result);
+    // 쿼리 파라미터 정규화 — 중복 파라미터(?q=a&q=b)로 배열이 와도 안전하게 string으로
+    const str = (v: unknown) => (typeof v === "string" ? v : "");
+    const page = Math.max(1, parseInt(str(req.query.page)) || 1);
+    const limit = Math.min(50, Math.max(1, parseInt(str(req.query.limit)) || 20));
+    const offset = (page - 1) * limit;
+
+    const typeId = str(req.query.typeId);
+    const q = str(req.query.q);
+    // year/month는 숫자만 허용 (LIKE 와일드카드 주입 차단)
+    const year = /^\d{4}$/.test(str(req.query.year)) ? str(req.query.year) : "";
+    const month = /^\d{1,2}$/.test(str(req.query.month)) ? str(req.query.month) : "";
+
+    // 동적 WHERE 조립 (date는 ISO/YYYY-MM-DD text라 prefix LIKE = 날짜 범위)
+    const conditions = [];
+    if (typeId) conditions.push(eq(worships.typeId, typeId));
+    if (q) {
+      // 사용자 입력의 LIKE 와일드카드(%, _, \)를 이스케이프
+      const esc = q.replace(/[\\%_]/g, (c) => `\\${c}`);
+      conditions.push(sql`${worships.title} like ${`%${esc}%`} escape '\\'`);
+    }
+    if (year && month) {
+      conditions.push(like(worships.date, `${year}-${month.padStart(2, "0")}-%`));
+    } else if (year) {
+      conditions.push(like(worships.date, `${year}-%`));
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const countRow = db
+      .select({ total: sql<number>`cast(count(*) as int)` })
+      .from(worships)
+      .where(where)
+      .get();
+    const total = countRow?.total ?? 0;
+
+    const items = db
+      .select()
+      .from(worships)
+      .where(where)
+      .orderBy(desc(worships.date), desc(worships.createdAt))
+      .limit(limit)
+      .offset(offset)
+      .all();
+
+    // sheets는 페이지 worshipId들을 한 번에 조회 → N+1 제거
+    const worshipIds = items.map((w) => w.id);
+    const allSheets =
+      worshipIds.length > 0 ? db.select().from(sheets).where(inArray(sheets.worshipId, worshipIds)).all() : [];
+    const sheetsByWorshipId = new Map<string, typeof allSheets>();
+    for (const sheet of allSheets) {
+      const arr = sheetsByWorshipId.get(sheet.worshipId) ?? [];
+      arr.push(sheet);
+      sheetsByWorshipId.set(sheet.worshipId, arr);
+    }
+
+    const result = items.map((w) => ({
+      ...w,
+      sheets: (sheetsByWorshipId.get(w.id) ?? []).sort((a, b) => a.order - b.order),
+    }));
+
+    const hasMore = offset + limit < total;
+    res.json({ items: result, total, page, hasMore, nextPage: hasMore ? page + 1 : null });
   } catch (error) {
     console.error("Failed to fetch worships:", error);
     res.status(500).json({ error: "Failed to fetch worships" });
+  }
+});
+
+// 연도 목록 (필터 드롭다운용) — 반드시 GET /:id 보다 앞에 등록할 것
+router.get("/years", (_req, res) => {
+  try {
+    const rows = db
+      .select({ year: sql<string>`substr(${worships.date}, 1, 4)` })
+      .from(worships)
+      .groupBy(sql`substr(${worships.date}, 1, 4)`)
+      .orderBy(desc(sql`substr(${worships.date}, 1, 4)`))
+      .all();
+    res.json(rows.map((r) => parseInt(r.year)).filter((y) => !Number.isNaN(y)));
+  } catch (error) {
+    console.error("Failed to fetch worship years:", error);
+    res.status(500).json({ error: "Failed to fetch worship years" });
   }
 });
 


### PR DESCRIPTION
## Summary
Major refactoring of the Worship page to improve maintainability and add pagination support. Extracted large inline components into dedicated modules, consolidated gesture/zoom logic into a custom hook, and implemented infinite scroll for the WorshipList with server-side filtering.

## Key Changes

### Component Extraction
- **WorshipHeader**: Top navigation bar with presence popover (extracted from Worship.tsx)
- **SheetListSidebar**: Left sidebar with sheet list and presence indicators (extracted from Worship.tsx)
- **DrawingToolbar**: Drawing mode toggle, tool options, undo/redo, command panel toggle (extracted from Worship.tsx)
- **CommandPanel**: Right-side command sending panel (extracted from Worship.tsx)
- **PageNavigator**: Bottom page navigation bar (extracted from Worship.tsx)
- **CommandToast & SpotlightToast**: Socket event toast components (extracted from Worship.tsx)

### Custom Hooks
- **useSheetZoomPan**: Consolidated all pinch-zoom, pan, and double-tap reset gesture logic (previously inline in Worship.tsx)
- **useWorshipRoom**: Worship room join/leave, connection state, and page change notifications
- **useWorshipPresence**: Presence updates, command/spotlight socket event handling

### Server & Query Changes
- **Infinite scroll pagination**: `useWorships()` now uses `useInfiniteQuery` with filters (typeId, q, year, month)
- **Server-side filtering**: `/worships` endpoint now supports query params for type, search, year, month with proper SQL WHERE clauses
- **New query hook**: `useWorshipYears()` for year filter dropdown
- **Debounced search**: 300ms debounce on search input to reduce server calls

### Utilities & Types
- **lib/canvas.ts**: Extracted canvas coordinate utilities (denormalizePoint, normalizePoint, getContainedRect, etc.) from SheetCanvas
- **panelMotion.ts**: Shared animation tokens for sidebar/command panel slides
- **PresenceUser type**: Moved to types/index.ts for reuse across components
- **WorshipPage type**: New paginated response type for infinite scroll

### UI & Styling
- Added Radix UI Select component for year/month filters
- Updated color scheme to use CSS variables (--viewer-panel, --viewer-border, etc.)
- Replaced hardcoded Tailwind colors with design tokens throughout
- Added Pretendard font to package.json

### Canvas Optimization
- Memoized SheetCanvas component
- Added EMPTY_PATHS and EMPTY_REMOTE constants to prevent unnecessary redraws
- Exported RemoteInProgressPath type for type safety

## Implementation Details

- **Gesture logic isolation**: `useSheetZoomPan` maintains all pinch/pan state (scale, translate, transformOrigin, refs) and provides resetZoom() for page navigation
- **Socket event consolidation**: `useWorshipPresence` handles all presence/command/spotlight events, reducing effect complexity in main component
- **Infinite scroll sentinel**: WorshipList uses IntersectionObserver on a sentinel element to trigger fetchNextPage
- **Filter reset behavior**: Changing filters scrolls to top and resets pagination (queryKey change triggers new fetch from page 1)
- **Panel animations**: Shared PANEL_EASE and transition tokens ensure consistent sidebar/command panel motion

https://claude.ai/code/session_01PYpcpkYAQC17YV7x6xJ5BA