### PR TITLE
ci: PR 자동 코드 리뷰(Claude Code) 워크플로 추가

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 한국어로 리뷰하고, 실제로 고칠 가치가 있는 것만 지적한다.
           prompt: |
             이 풀 리퀘스트를 코드 리뷰해 주세요. 리뷰는 한국어로 작성합니다.
@@ -57,5 +57,5 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 15"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+# PR이 열리거나(또는 draft -> ready 전환, 재오픈) 될 때 Claude가 자동으로 코드 리뷰를 남긴다.
+# (push마다 재리뷰하지 않도록 synchronize는 제외 — 필요하면 PR에 "@claude review" 코멘트로 수동 트리거)
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    # 드래프트 PR은 리뷰하지 않음
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # 한국어로 리뷰하고, 실제로 고칠 가치가 있는 것만 지적한다.
+          prompt: |
+            이 풀 리퀘스트를 코드 리뷰해 주세요. 리뷰는 한국어로 작성합니다.
+            다음을 중점적으로 봐주세요:
+            - 버그·로직 오류, 엣지 케이스, 경쟁 상태
+            - 보안 취약점(입력 검증, 인증/인가, 비밀값 노출)
+            - 성능 문제 및 불필요한 리렌더
+            - 테스트 누락
+            - 저장소 루트의 CLAUDE.md / client/CLAUDE.md 규칙 위반(특히 좌표 정규화·DPR, 프로필 가드, 화이트보드 드로잉 원칙)
+            확실한 문제는 해당 코드 줄에 인라인 코멘트로, 전반 요약은 PR 코멘트로 남겨주세요.
+            사소한 스타일 지적은 피하고, 우선순위(P1/P2/P3)를 함께 표기하세요.
+          claude_args: "--max-turns 15"
+          track_progress: true

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,20 +1,25 @@
 name: Claude Code Review
 
-# PR이 열리거나(또는 draft -> ready 전환, 재오픈) 될 때 Claude가 자동으로 코드 리뷰를 남긴다.
-# (push마다 재리뷰하지 않도록 synchronize는 제외 — 필요하면 PR에 "@claude review" 코멘트로 수동 트리거)
+# - PR이 열리거나(draft -> ready 전환, 재오픈) 될 때 Claude가 자동으로 코드 리뷰를 남긴다.
+# - PR 코멘트에 "@claude ..."(예: "@claude review")를 남기면 수동으로 재리뷰/질문을 트리거한다.
+#   (GitHub은 PR 대화 코멘트를 issue_comment 이벤트로 전달하므로 해당 트리거가 필요)
+# - push마다 재리뷰하지 않도록 pull_request synchronize는 일부러 제외했다.
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: read
   id-token: write
 
 jobs:
-  review:
-    # 드래프트 PR은 리뷰하지 않음
-    if: github.event.pull_request.draft == false
+  # PR open/ready/reopen 시 자동 코드 리뷰 (draft 제외)
+  auto-review:
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,3 +42,20 @@ jobs:
             사소한 스타일 지적은 피하고, 우선순위(P1/P2/P3)를 함께 표기하세요.
           claude_args: "--max-turns 15"
           track_progress: true
+
+  # PR 코멘트에 "@claude" 멘션이 있으면 수동 트리거(재리뷰·질문·수정 요청)
+  mention:
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 15"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -31,6 +31,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 한국어로 리뷰하고, 실제로 고칠 가치가 있는 것만 지적한다.
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             이 풀 리퀘스트를 코드 리뷰해 주세요. 리뷰는 한국어로 작성합니다.
             다음을 중점적으로 봐주세요:
             - 버그·로직 오류, 엣지 케이스, 경쟁 상태
@@ -38,9 +41,13 @@ jobs:
             - 성능 문제 및 불필요한 리렌더
             - 테스트 누락
             - 저장소 루트의 CLAUDE.md / client/CLAUDE.md 규칙 위반(특히 좌표 정규화·DPR, 프로필 가드, 화이트보드 드로잉 원칙)
-            확실한 문제는 해당 코드 줄에 인라인 코멘트로, 전반 요약은 PR 코멘트로 남겨주세요.
+            확실한 문제는 `mcp__github_inline_comment__create_inline_comment` 로 해당 코드 줄에
+            **인라인 코멘트**를 남기고, 전반 요약은 PR 상단 코멘트로 남겨주세요.
             사소한 스타일 지적은 피하고, 우선순위(P1/P2/P3)를 함께 표기하세요.
-          claude_args: "--max-turns 15"
+          # 인라인 코멘트 도구는 자동 리뷰 경로에서 기본 비활성이라 명시 허용해야 한다.
+          claude_args: |
+            --max-turns 15
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           track_progress: true
 
   # PR 코멘트에 "@claude" 멘션이 있으면 수동 트리거(재리뷰·질문·수정 요청)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Git
 
 - 커밋 메시지에 `Co-Authored-By` 태그 절대 붙이지 않기
+- PR 본문/설명에 `🤖 Generated with Claude Code` 등 Claude Code 생성 표기·서명 붙이지 않기
 - `develop` 브랜치에서 개발 → `main`에 머지/push 시 Railway 자동 배포
 - 평소 작업은 `develop`에서 진행할 것
 


### PR DESCRIPTION
## 목적
GitHub에 PR이 올라오면 **Claude Code가 자동으로 코드 리뷰**를 남기도록 설정합니다 (Codex 자동 리뷰와 동일한 흐름).

## 변경
- **`.github/workflows/claude-pr-review.yml`** (신규)
  - `auto-review` 잡: `pull_request` `opened`/`reopened`/`ready_for_review` 시 **멘션 없이 자동** 리뷰 (draft 스킵, `synchronize` 제외)
  - `mention` 잡: PR 코멘트에 `@claude ...`(예: `@claude review`) 작성 시 수동 트리거(`issue_comment`)
  - 액션: `anthropics/claude-code-action@v1`, 한국어 인라인+요약 리뷰, `CLAUDE.md` 규칙 점검, 우선순위 표기
  - 인증: **구독(OAuth 토큰)** 방식 — `claude_code_oauth_token`
- **`CLAUDE.md`**: "PR 본문에 Claude Code 생성 표기·서명 붙이지 않기" 규칙 추가

## ⚠️ 동작에 필요한 1회 수동 설정 (저장소 관리자만 가능)
1. **Claude GitHub App 설치**: https://github.com/apps/claude → Install → 이 저장소 선택
2. **구독 OAuth 토큰 생성·등록** (Pro/Max 구독 사용량으로 청구):
   - 로컬 터미널에서 `claude setup-token` 실행 → 브라우저 인증 → **1년 유효 토큰** 출력
   - 저장소 **Settings → Secrets and variables → Actions → New repository secret**
   - Name: `CLAUDE_CODE_OAUTH_TOKEN`, Value: 위 토큰
   - (대안: 종량제 API 키를 쓰려면 워크플로의 `claude_code_oauth_token` → `anthropic_api_key`, 시크릿 `ANTHROPIC_API_KEY`로 교체)
3. 이 워크플로가 **develop/main에 머지되면** 그 브랜치로 향하는 PR부터 자동 리뷰가 동작합니다. (`pull_request` 워크플로는 base 브랜치의 워크플로 파일을 사용 — develop→main 릴리스 시 main에도 반영)

## 참고
- ⚠️ **구독 한도 공유**: OAuth 토큰 사용량은 인터랙티브 Claude 사용과 **같은 구독 한도**를 공유합니다. 리뷰가 잦거나 코드베이스가 크면 그 달 대화용 한도를 깎을 수 있어, 사용량이 많으면 API 키(별도 예산)가 나을 수 있습니다.
- 포크에서 온 PR은 보안상 쓰기 권한이 제한될 수 있음(GitHub App 기본 동작).