### PR TITLE
feat: 예배 날짜 선택 시 예배 제목 자동 채움

### DIFF
--- a/client/src/lib/date.ts
+++ b/client/src/lib/date.ts
@@ -1,0 +1,13 @@
+/**
+ * "2026-07-02" → "2026년 7월 2일". 형식이 맞지 않으면 "" 반환.
+ *
+ * Date 객체를 쓰지 않는 이유: `new Date("2026-07-02")`는 ES 스펙상 UTC 자정으로
+ * 파싱된다. KST(UTC+9)에선 우연히 같은 날이 나오지만 UTC 음수 오프셋 환경에선
+ * 하루 밀린다. YYYY-MM-DD는 이미 사람이 읽는 형태라 문자열 분해가 타임존에 무관하다.
+ */
+export function formatKoreanDate(date: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return "";
+  const [, year, month, day] = match;
+  return `${year}년 ${Number(month)}월 ${Number(day)}일`;
+}

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/hooks/queries";
 import type { Sheet } from "@/types";
 import { cn } from "@/lib/utils";
+import { formatKoreanDate } from "@/lib/date";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -282,11 +283,33 @@ export default function WorshipEdit() {
     return undefined;
   }, [worshipData, isNew, worshipTypes]);
 
-  const { register, handleSubmit, control, getValues } = useForm<WorshipFormValues>({
+  const { register, handleSubmit, control, getValues, setValue } = useForm<WorshipFormValues>({
     defaultValues: { title: "", date: "", typeId: "" },
     values: formValues,
     resetOptions: { keepDirtyValues: true },
   });
+
+  const dateField = register("date", { required: true });
+
+  // 날짜·유형에서 파생되는 기본 제목 — 날짜가 없으면 제목도 만들지 않는다
+  const buildAutoTitle = (date: string, typeId: string) => {
+    const dateLabel = formatKoreanDate(date);
+    if (!dateLabel) return "";
+    const typeName = worshipTypes.find((t) => t.id === typeId)?.name;
+    return typeName ? `${dateLabel} ${typeName}` : dateLabel;
+  };
+
+  // 제목이 비었거나 직전 날짜·유형에서 자동 생성된 값 그대로일 때만 갱신 —
+  // 사용자가 직접 쓴 제목("주일예배 3부")은 날짜를 바꿔도 건드리지 않는다
+  const syncAutoTitle = (prev: { date: string; typeId: string }, next: { date: string; typeId: string }) => {
+    const currentTitle = getValues("title");
+    if (currentTitle.trim() !== "" && currentTitle !== buildAutoTitle(prev.date, prev.typeId)) return;
+    const nextTitle = buildAutoTitle(next.date, next.typeId);
+    if (!nextTitle) return;
+    // shouldDirty 필수 — values + keepDirtyValues 조합이라 dirty가 아니면
+    // worshipTypes가 늦게 도착해 formValues가 갱신될 때 빈 값으로 되돌아간다
+    setValue("title", nextTitle, { shouldDirty: true, shouldValidate: true });
+  };
 
   // 기존 예배의 악보 목록 로드 (악보 리스트는 서버 상태와 동기화 유지가 의도된 동작)
   useEffect(() => {
@@ -313,12 +336,13 @@ export default function WorshipEdit() {
     let currentWorshipId = worshipId;
     if (!currentWorshipId) {
       const { title, date, typeId } = getValues();
-      if (!title.trim()) {
-        toast.error("악보를 추가하려면 먼저 예배 제목을 입력해주세요.");
-        return;
-      }
+      // 제목은 날짜에서 자동으로 채워지므로 날짜를 먼저 지적해야 실제 원인과 맞는다
       if (!date) {
         toast.error("악보를 추가하려면 먼저 예배 날짜를 선택해주세요.");
+        return;
+      }
+      if (!title.trim()) {
+        toast.error("악보를 추가하려면 먼저 예배 제목을 입력해주세요.");
         return;
       }
       if (!typeId) {
@@ -482,7 +506,7 @@ export default function WorshipEdit() {
                   id="worship-title"
                   type="text"
                   {...register("title", { validate: (v) => v.trim().length > 0 })}
-                  placeholder="예: 2024년 1월 첫째주 주일예배"
+                  placeholder="날짜를 선택하면 자동으로 채워집니다"
                   className="h-11"
                 />
               </div>
@@ -495,7 +519,13 @@ export default function WorshipEdit() {
                 <Input
                   id="worship-date"
                   type="date"
-                  {...register("date", { required: true })}
+                  {...dateField}
+                  onChange={(e) => {
+                    // 이전 값은 RHF가 내부 store를 갱신하기 전에 잡아둔다
+                    const { date: prevDate, typeId } = getValues();
+                    void dateField.onChange(e);
+                    syncAutoTitle({ date: prevDate, typeId }, { date: e.target.value, typeId });
+                  }}
                   className="h-11 appearance-none"
                 />
               </div>
@@ -513,7 +543,14 @@ export default function WorshipEdit() {
                       <Select
                         items={Object.fromEntries(worshipTypes.map((t) => [t.id, t.name]))}
                         value={field.value}
-                        onValueChange={field.onChange}
+                        onValueChange={(value) => {
+                          const { date, typeId: prevTypeId } = getValues();
+                          field.onChange(value);
+                          // base-ui는 해제 시 null을 보낼 수 있다 — 그 경우 제목은 그대로 둔다
+                          if (typeof value === "string") {
+                            syncAutoTitle({ date, typeId: prevTypeId }, { date, typeId: value });
+                          }
+                        }}
                       >
                         <SelectTrigger className="w-full data-[size=default]:h-11">
                           <SelectValue placeholder="예배 유형 선택" />

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, ChangeEvent } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, ChangeEvent } from "react";
 import { Link, Navigate, useParams, useNavigate } from "react-router";
 import { useForm, Controller } from "react-hook-form";
 import { isAxiosError } from "axios";
@@ -43,7 +43,7 @@ import {
   useDeleteSheet,
   useReorderSheets,
 } from "@/hooks/queries";
-import type { Sheet } from "@/types";
+import type { Sheet, WorshipType } from "@/types";
 import { cn } from "@/lib/utils";
 import { formatKoreanDate } from "@/lib/date";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -248,6 +248,15 @@ type WorshipFormValues = {
   typeId: string;
 };
 
+// 날짜·유형에서 파생되는 기본 제목 — 날짜가 없으면 제목도 만들지 않는다.
+// 유형을 못 찾으면(아직 로딩 전이거나 빈 typeId) 날짜만으로 만든다.
+function buildAutoTitle(date: string, typeId: string, types: WorshipType[]): string {
+  const dateLabel = formatKoreanDate(date);
+  if (!dateLabel) return "";
+  const typeName = types.find((t) => t.id === typeId)?.name;
+  return typeName ? `${dateLabel} ${typeName}` : dateLabel;
+}
+
 export default function WorshipEdit() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -291,25 +300,32 @@ export default function WorshipEdit() {
 
   const dateField = register("date", { required: true });
 
-  // 날짜·유형에서 파생되는 기본 제목 — 날짜가 없으면 제목도 만들지 않는다
-  const buildAutoTitle = (date: string, typeId: string) => {
-    const dateLabel = formatKoreanDate(date);
-    if (!dateLabel) return "";
-    const typeName = worshipTypes.find((t) => t.id === typeId)?.name;
-    return typeName ? `${dateLabel} ${typeName}` : dateLabel;
-  };
-
   // 제목이 비었거나 직전 날짜·유형에서 자동 생성된 값 그대로일 때만 갱신 —
   // 사용자가 직접 쓴 제목("주일예배 3부")은 날짜를 바꿔도 건드리지 않는다
-  const syncAutoTitle = (prev: { date: string; typeId: string }, next: { date: string; typeId: string }) => {
-    const currentTitle = getValues("title");
-    if (currentTitle.trim() !== "" && currentTitle !== buildAutoTitle(prev.date, prev.typeId)) return;
-    const nextTitle = buildAutoTitle(next.date, next.typeId);
-    if (!nextTitle) return;
-    // shouldDirty 필수 — values + keepDirtyValues 조합이라 dirty가 아니면
-    // worshipTypes가 늦게 도착해 formValues가 갱신될 때 빈 값으로 되돌아간다
-    setValue("title", nextTitle, { shouldDirty: true, shouldValidate: true });
-  };
+  const syncAutoTitle = useCallback(
+    (prev: { date: string; typeId: string }, next: { date: string; typeId: string }) => {
+      const currentTitle = getValues("title");
+      if (currentTitle.trim() !== "" && currentTitle !== buildAutoTitle(prev.date, prev.typeId, worshipTypes)) return;
+      const nextTitle = buildAutoTitle(next.date, next.typeId, worshipTypes);
+      if (!nextTitle) return;
+      // shouldDirty 필수 — values + keepDirtyValues 조합이라 dirty가 아니면
+      // worshipTypes가 늦게 도착해 formValues가 갱신될 때 빈 값으로 되돌아간다
+      setValue("title", nextTitle, { shouldDirty: true, shouldValidate: true });
+    },
+    [worshipTypes, getValues, setValue],
+  );
+
+  // worshipTypes가 늦게 도착하면 typeId는 values 리셋으로 조용히 채워진다 — Select의
+  // onValueChange를 거치지 않으므로 syncAutoTitle이 불리지 않는다. 그 사이 사용자가
+  // 날짜를 골랐다면 제목이 유형명 없이("2026년 7월 2일") 굳고, 이후 날짜를 바꿔도
+  // 직전 자동 제목과 불일치해 "직접 쓴 제목"으로 오인돼 영영 갱신이 멈춘다.
+  // 유형이 도착한 시점에 한 번 맞춰준다 — prev.typeId를 ""로 두는 게 곧 "유형을 몰랐을 때"다.
+  useEffect(() => {
+    if (!isNew || worshipTypes.length === 0) return;
+    const { date, typeId } = getValues();
+    if (!date || !typeId) return;
+    syncAutoTitle({ date, typeId: "" }, { date, typeId });
+  }, [isNew, worshipTypes, syncAutoTitle, getValues]);
 
   // 기존 예배의 악보 목록 로드 (악보 리스트는 서버 상태와 동기화 유지가 의도된 동작)
   useEffect(() => {

--- a/client/src/pages/WorshipEdit.tsx
+++ b/client/src/pages/WorshipEdit.tsx
@@ -307,7 +307,14 @@ export default function WorshipEdit() {
       const currentTitle = getValues("title");
       if (currentTitle.trim() !== "" && currentTitle !== buildAutoTitle(prev.date, prev.typeId, worshipTypes)) return;
       const nextTitle = buildAutoTitle(next.date, next.typeId, worshipTypes);
-      if (!nextTitle) return;
+      // 날짜를 비우면 제목도 함께 비운다. 그냥 두면 form이 date="" / title="옛 날짜 제목"인
+      // 불일치 상태가 되고, 다음에 날짜를 고를 때 buildAutoTitle(prev)가 ""라 현재 제목이
+      // "직접 쓴 제목"으로 오인돼 이후 갱신이 영영 멈춘다.
+      // 여기는 위 가드를 통과한 지점(= 제목이 비었거나 자동 생성값)이라 사용자가 쓴 제목은 지워지지 않는다
+      if (!nextTitle) {
+        if (getValues("title") !== "") setValue("title", "", { shouldDirty: true });
+        return;
+      }
       // shouldDirty 필수 — values + keepDirtyValues 조합이라 dirty가 아니면
       // worshipTypes가 늦게 도착해 formValues가 갱신될 때 빈 값으로 되돌아간다
       setValue("title", nextTitle, { shouldDirty: true, shouldValidate: true });
@@ -463,8 +470,10 @@ export default function WorshipEdit() {
       }
     },
     (errors) => {
-      if (errors.title) toast.error("예배 제목을 입력해주세요.");
-      else if (errors.date) toast.error("예배 날짜를 선택해주세요.");
+      // 업로드 가드와 같은 순서 — 제목은 날짜에서 자동으로 채워지므로 날짜를 먼저 지적해야
+      // 실제 원인과 맞고, RHF가 포커스를 옮기는 필드(mount 순서상 date가 먼저)와도 일치한다
+      if (errors.date) toast.error("예배 날짜를 선택해주세요.");
+      else if (errors.title) toast.error("예배 제목을 입력해주세요.");
     },
   );
 

--- a/client/src/pages/WorshipList.tsx
+++ b/client/src/pages/WorshipList.tsx
@@ -5,6 +5,7 @@ import { useWorships, useWorshipYears, useWorshipTypes, useDeleteWorship } from 
 import { useAppStore } from "@/store/appStore";
 import { getColorOption } from "@/lib/colors";
 import { cn } from "@/lib/utils";
+import { formatKoreanDate } from "@/lib/date";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -72,15 +73,6 @@ export default function WorshipList() {
     observer.observe(el);
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
 
   const formatLastEdited = (dateString: string) => {
     const date = new Date(dateString);
@@ -290,7 +282,7 @@ export default function WorshipList() {
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
                           <div className="flex items-center gap-1 text-sm text-muted-foreground">
                             <Calendar className="size-4 shrink-0" />
-                            {formatDate(worship.date)}
+                            {formatKoreanDate(worship.date) || worship.date}
                           </div>
                           <div className="text-sm text-muted-foreground">악보 {worship.sheets?.length ?? 0}개</div>
                           {worshipType && (


### PR DESCRIPTION
## 배경

예배를 만들 때 제목을 매번 손으로 타이핑해야 했다. 대부분 "그 날짜의 그 예배"라 제목에 쓸 말이 마땅치 않은데도, 제목이 비면 저장(`validate`)과 악보 업로드가 모두 막혀서 사용자가 날짜를 한글로 옮겨 적는 작업을 반복하고 있었다.

## 변경 내용

날짜를 고르면 제목이 **`2026년 7월 2일 주일 1부 예배`** 형식으로 자동으로 채워진다. 예배 유형을 바꾸면 뒷부분도 따라간다.

**덮어쓰기 규칙** — 제목이 비었거나 **직전 날짜·유형에서 자동 생성된 값 그대로**일 때만 갱신한다.
- 직접 쓴 제목(`주일예배 3부`)은 날짜·유형을 바꿔도 그대로 유지된다
- 편집 모드에서 기존 예배를 열어도 동일하게 동작한다 (커스텀 제목 보존)
- 제목을 비우면 다시 자동으로 채워진다

### 파일별

- **`client/src/lib/date.ts`** (신규) — `formatKoreanDate("2026-07-02")` → `"2026년 7월 2일"`. `Date` 객체 대신 문자열을 분해한다. `new Date("2026-07-02")`는 ES 스펙상 UTC 자정으로 파싱돼 UTC 음수 오프셋 환경에서 하루 밀리는 문제가 있었다.
- **`client/src/pages/WorshipEdit.tsx`** — `buildAutoTitle` / `syncAutoTitle` 추가. `register("date")`의 `onChange`와 유형 `Select`의 `onValueChange`를 래핑해 기존 동작을 보존한 채 로직을 끼워 넣었다. `setValue`의 `shouldDirty: true`는 필수 — `values` + `keepDirtyValues` 조합이라 dirty가 아니면 `worshipTypes`가 늦게 도착할 때 빈 값으로 되돌아간다.
- **`client/src/pages/WorshipList.tsx`** — 로컬 `formatDate`를 `formatKoreanDate`로 대체. 목록 표기와 자동 제목이 같은 함수에서 나오므로 형식이 갈라지지 않고, 위의 UTC 파싱 버그도 함께 사라진다.
- 악보 업로드 선저장 가드에서 **날짜를 제목보다 먼저 검사**하도록 순서 변경 — 제목이 자동으로 채워지므로 "제목이 비었다"는 사실상 "날짜를 안 골랐다"는 뜻이고, 기존 순서면 실제 원인과 다른 토스트가 떴다.
- placeholder: `예: 2024년 1월 첫째주 주일예배` → `날짜를 선택하면 자동으로 채워집니다`

서버·DB·전송 포맷(`YYYY-MM-DD`)은 건드리지 않았다. 순수 클라이언트 UX 변경이다.

## 검증

`npm run check` (타입체크 + ESLint + prettier) 통과, warning 0. 서버 테스트 26개 통과(이번 변경과 무관하나 baseline 확인).

Playwright로 **아이패드 세로 834×1194**와 **아이폰 390×844** 두 크기에서 아래 시나리오 전부 확인 — 28/28 통과.

생성 화면:
1. 날짜 선택 → 제목 자동 채움
2. 날짜 변경 → 자동 제목이 따라감
3. 유형 변경 → 제목 뒷부분 갱신
4. 제목 직접 수정 후 날짜/유형 변경 → **제목 유지**
5. 제목을 비우면 다시 자동 채움
6. 저장 후 목록에서 제목과 날짜 표기가 서로 일치

편집 화면:

7. 커스텀 제목(`주일예배 3부`) → 날짜·유형 변경에도 유지
8. 자동형 제목 → 날짜를 따라감
9. 아무 조작 없이 열기만 하면 서버 값 그대로 (덮어쓰기 없음)
