### PR TITLE
refactor: 날짜 처리를 date-fns로 통일

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@date-fns/tz": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -1753,12 +1752,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@date-fns/tz": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
-      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
-      "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -4519,6 +4512,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
+        "@date-fns/tz": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -20,6 +21,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "date-fns": "^4.4.0",
         "lucide-react": "^0.576.0",
         "motion": "^12.38.0",
         "pretendard": "^1.3.9",
@@ -1751,6 +1753,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -6313,6 +6321,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@date-fns/tz": "^1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@date-fns/tz": "^1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
@@ -26,6 +27,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "date-fns": "^4.4.0",
     "lucide-react": "^0.576.0",
     "motion": "^12.38.0",
     "pretendard": "^1.3.9",

--- a/client/src/lib/date.ts
+++ b/client/src/lib/date.ts
@@ -1,14 +1,24 @@
 import { format, isValid, parse, parseISO } from "date-fns";
 
 /**
- * "2026-07-02" → "2026년 7월 2일". 파싱 실패 시 "" 반환.
+ * "2026-07-02" → "2026년 7월 2일". 형식이 어긋나거나 없는 날짜면 "" 반환.
  *
- * `parseISO`가 아니라 `parse`를 쓰는 이유: `parseISO`는 "2026-07"이나
- * "2026-07-02T10:00:00Z"도 통과시킨다. `parse`는 형식을 정확히 강제한다.
- * 둘 다 로컬 자정으로 파싱되므로 `new Date("2026-07-02")`(UTC 자정)처럼
+ * 정규식과 `parse`를 함께 쓴다 — 한쪽만으로는 구멍이 남는다.
+ * - 정규식: 자릿수를 강제한다. `parse`는 "2026-7-2"나 "26-07-02"(→ 0026년)도
+ *   통과시키는데, 그런 값은 서버의 월 필터(`LIKE 'YYYY-MM-%'`)에서 누락되므로
+ *   화면에만 멀쩡해 보이는 유령 데이터가 된다
+ * - `parse`: 달력 유효성을 본다. 정규식만으로는 "2026-13-01"이나 "2026-02-31"이
+ *   "2026년 13월 1일"처럼 그대로 렌더된다
+ *
+ * `parseISO`를 안 쓰는 이유는 "2026-07"이나 "2026-07-02T10:00:00Z"까지 통과시켜서다.
+ * `parse`는 로컬 자정으로 파싱하므로 `new Date("2026-07-02")`(UTC 자정)처럼
  * UTC 음수 오프셋 환경에서 하루 밀리는 문제가 없다.
+ *
+ * "" 반환은 호출부의 계약이다 — `buildAutoTitle`은 "자동 제목을 만들지 않는다"는
+ * 신호로, 예배 목록은 원문 표시 폴백(`|| worship.date`)으로 쓴다.
  */
 export function formatKoreanDate(date: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return "";
   const parsed = parse(date, "yyyy-MM-dd", new Date());
   if (!isValid(parsed)) return "";
   return format(parsed, "yyyy년 M월 d일");

--- a/client/src/lib/date.ts
+++ b/client/src/lib/date.ts
@@ -1,13 +1,22 @@
+import { format, isValid, parse, parseISO } from "date-fns";
+
 /**
- * "2026-07-02" → "2026년 7월 2일". 형식이 맞지 않으면 "" 반환.
+ * "2026-07-02" → "2026년 7월 2일". 파싱 실패 시 "" 반환.
  *
- * Date 객체를 쓰지 않는 이유: `new Date("2026-07-02")`는 ES 스펙상 UTC 자정으로
- * 파싱된다. KST(UTC+9)에선 우연히 같은 날이 나오지만 UTC 음수 오프셋 환경에선
- * 하루 밀린다. YYYY-MM-DD는 이미 사람이 읽는 형태라 문자열 분해가 타임존에 무관하다.
+ * `parseISO`가 아니라 `parse`를 쓰는 이유: `parseISO`는 "2026-07"이나
+ * "2026-07-02T10:00:00Z"도 통과시킨다. `parse`는 형식을 정확히 강제한다.
+ * 둘 다 로컬 자정으로 파싱되므로 `new Date("2026-07-02")`(UTC 자정)처럼
+ * UTC 음수 오프셋 환경에서 하루 밀리는 문제가 없다.
  */
 export function formatKoreanDate(date: string): string {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
-  if (!match) return "";
-  const [, year, month, day] = match;
-  return `${year}년 ${Number(month)}월 ${Number(day)}일`;
+  const parsed = parse(date, "yyyy-MM-dd", new Date());
+  if (!isValid(parsed)) return "";
+  return format(parsed, "yyyy년 M월 d일");
+}
+
+/** ISO 타임스탬프 → "2026. 7. 2." (뷰어의 로컬 날짜 기준). 파싱 실패 시 "" 반환 */
+export function formatKoreanDateShort(iso: string): string {
+  const parsed = parseISO(iso);
+  if (!isValid(parsed)) return "";
+  return format(parsed, "yyyy. M. d.");
 }

--- a/client/src/pages/WorshipList.tsx
+++ b/client/src/pages/WorshipList.tsx
@@ -5,7 +5,7 @@ import { useWorships, useWorshipYears, useWorshipTypes, useDeleteWorship } from 
 import { useAppStore } from "@/store/appStore";
 import { getColorOption } from "@/lib/colors";
 import { cn } from "@/lib/utils";
-import { formatKoreanDate } from "@/lib/date";
+import { formatKoreanDate, formatKoreanDateShort } from "@/lib/date";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -73,11 +73,6 @@ export default function WorshipList() {
     observer.observe(el);
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const formatLastEdited = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("ko-KR");
-  };
 
   const handleDelete = async (id: string) => {
     await deleteWorshipMutation.mutateAsync(id);
@@ -293,7 +288,7 @@ export default function WorshipList() {
                         </div>
                       </div>
                       <div className="text-sm text-muted-foreground">
-                        마지막 수정: {formatLastEdited(worship.updatedAt)}
+                        마지막 수정: {formatKoreanDateShort(worship.updatedAt)}
                       </div>
                     </div>
 

--- a/server/__tests__/date.test.ts
+++ b/server/__tests__/date.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { nowIso } from "../lib/date.js";
+
+// nowIso()의 계약: Date.prototype.toISOString()과 **바이트 단위로 동일한** 문자열.
+//
+// created_at/updated_at은 worships.ts의 `orderBy(desc(...))` 사전순 정렬에 쓰인다.
+// 형식이 한 글자라도 달라지면 기존 행과 섞이면서 정렬이 조용히 틀어지고,
+// 이미 배포된 DB의 데이터와 어긋난다. date-fns의 formatISO()는 로컬
+// 오프셋(+09:00) 형식에 밀리초도 없어 여기 쓸 수 없다 — 그래서 TZDate + 명시적
+// 포맷을 쓰며, 이 테스트가 그 등가성을 지킨다.
+
+const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+describe("nowIso", () => {
+  it("toISOString()과 동일한 형식이다", () => {
+    expect(nowIso()).toMatch(ISO_UTC);
+  });
+
+  it("항상 24자다", () => {
+    expect(nowIso()).toHaveLength(24);
+  });
+
+  it("현재 시각을 UTC로 찍는다", () => {
+    const before = Date.now();
+    const value = nowIso();
+    const after = Date.now();
+
+    const parsed = Date.parse(value);
+    expect(Number.isNaN(parsed)).toBe(false);
+    expect(parsed).toBeGreaterThanOrEqual(before - 1);
+    expect(parsed).toBeLessThanOrEqual(after + 1);
+  });
+
+  it("같은 순간에 대해 toISOString()과 글자까지 일치한다", () => {
+    // nowIso()는 인자를 받지 않으므로 두 값을 연속 호출해 밀리초가 같을 때만 비교.
+    // 최대 50회 시도하면 같은 밀리초에 걸리는 케이스가 사실상 항상 나온다.
+    let compared = 0;
+    for (let i = 0; i < 50; i++) {
+      const a = new Date().toISOString();
+      const b = nowIso();
+      if (a.slice(0, 23) === b.slice(0, 23)) {
+        expect(b).toBe(a);
+        compared++;
+      }
+    }
+    expect(compared).toBeGreaterThan(0);
+  });
+
+  it("사전순 정렬이 시간순과 일치한다", async () => {
+    const first = nowIso();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = nowIso();
+
+    expect(first < second).toBe(true);
+    expect([second, first].sort()).toEqual([first, second]);
+  });
+});

--- a/server/db/migrateDrawingCoords.ts
+++ b/server/db/migrateDrawingCoords.ts
@@ -22,6 +22,7 @@ import { db, sqlite } from ".";
 import { drawingPaths, sheets } from "./schema.js";
 import { config } from "../config.js";
 import { convertPathToCardBasis, type Point } from "./drawingCoordConvert.js";
+import { nowIso } from "../lib/date.js";
 
 const FLAG_KEY = "drawing_coords_card_basis";
 
@@ -109,9 +110,7 @@ export async function runDrawingCoordMigration(): Promise<MigrationResult> {
       update.run(JSON.stringify(result.points), result.width, row.id);
       converted++;
     }
-    sqlite
-      .prepare("INSERT OR REPLACE INTO app_meta (key, value) VALUES (?, ?)")
-      .run(FLAG_KEY, new Date().toISOString());
+    sqlite.prepare("INSERT OR REPLACE INTO app_meta (key, value) VALUES (?, ?)").run(FLAG_KEY, nowIso());
   });
   runAll();
 

--- a/server/db/seed.ts
+++ b/server/db/seed.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { db } from ".";
 import { worshipTypes, roles, profiles, commands, worships, sheets, drawingPaths } from "./schema.js";
 import { setupDatabase } from "./setup.js";
+import { nowIso } from "../lib/date.js";
 
 async function seed() {
   console.log("Seeding database...\n");
@@ -79,7 +80,7 @@ async function seed() {
   const juil2buType = worshipTypeData.find((t) => t.name === "주일 2부 예배")!;
   const suyoType = worshipTypeData.find((t) => t.name === "수요예배")!;
 
-  const now = new Date().toISOString();
+  const now = nowIso();
   const worshipData = [
     {
       id: nanoid(),

--- a/server/lib/date.ts
+++ b/server/lib/date.ts
@@ -1,0 +1,15 @@
+import { format } from "date-fns";
+import { TZDate } from "@date-fns/tz";
+
+/**
+ * 저장용 UTC ISO 타임스탬프 — `2026-07-25T03:34:56.789Z`
+ *
+ * `TZDate`로 UTC에 고정하고 밀리초·`Z`까지 명시해 `Date.toISOString()`과
+ * 바이트 단위로 동일한 문자열을 만든다. created_at/updated_at은
+ * `orderBy(desc(...))` 사전순 정렬에 쓰이므로 형식이 바뀌면 기존 행과 섞여
+ * 정렬이 조용히 틀어진다 — date-fns의 `formatISO()`는 로컬 오프셋(+09:00)에
+ * 밀리초도 없어 여기 쓸 수 없다.
+ */
+export function nowIso(): string {
+  return format(new TZDate(Date.now(), "UTC"), "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,9 +8,11 @@
       "name": "gilteun-server",
       "version": "1.0.0",
       "dependencies": {
+        "@date-fns/tz": "^1.5.0",
         "better-sqlite3": "^12.11.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
+        "date-fns": "^4.4.0",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.45.1",
         "express": "^5.2.1",
@@ -37,7 +39,16 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.1",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": "^24.0.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -2949,6 +2960,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,9 +17,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.5.0",
     "better-sqlite3": "^12.11.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
+    "date-fns": "^4.4.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.1",
     "express": "^5.2.1",

--- a/server/routes/sheets.ts
+++ b/server/routes/sheets.ts
@@ -9,6 +9,7 @@ import sharp from "sharp";
 import { db } from "../db";
 import { sheets, drawingPaths } from "../db/schema.js";
 import { config } from "../config.js";
+import { nowIso } from "../lib/date.js";
 
 const router = Router();
 
@@ -84,7 +85,7 @@ router.post("/worships/:worshipId/sheets", upload.single("image"), async (req, r
 
     const id = nanoid();
     const imagePath = `sheets/${finalFilename}`;
-    const now = new Date().toISOString();
+    const now = nowIso();
 
     db.insert(sheets)
       .values({

--- a/server/routes/worships.ts
+++ b/server/routes/worships.ts
@@ -7,6 +7,7 @@ import path from "path";
 import { db } from "../db";
 import { worships, sheets, drawingPaths } from "../db/schema.js";
 import { config } from "../config.js";
+import { nowIso } from "../lib/date.js";
 
 const router = Router();
 
@@ -103,7 +104,7 @@ router.post("/", (req, res) => {
       return;
     }
     const id = nanoid();
-    const now = new Date().toISOString();
+    const now = nowIso();
     db.insert(worships).values({ id, title, date, typeId, createdAt: now, updatedAt: now }).run();
     const created = db.select().from(worships).where(eq(worships.id, id)).get();
     res.status(201).json({ ...created, sheets: [] });
@@ -143,7 +144,7 @@ router.put("/:id", (req, res) => {
       res.status(404).json({ error: "Worship not found" });
       return;
     }
-    const now = new Date().toISOString();
+    const now = nowIso();
     db.update(worships)
       .set({
         title: title ?? existing.title,

--- a/server/socket/drawingHandler.ts
+++ b/server/socket/drawingHandler.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db";
 import { drawingPaths } from "../db/schema.js";
+import { nowIso } from "../lib/date.js";
 
 export function setupDrawingHandler(io: Server, socket: Socket): void {
   // Sheet Room 입장 → 기존 드로잉 전송
@@ -62,7 +63,7 @@ export function setupDrawingHandler(io: Server, socket: Socket): void {
     }) => {
       try {
         const id = data.pathId || nanoid();
-        const now = new Date().toISOString();
+        const now = nowIso();
         // 동일 id 재전송(재연결 flush 등)은 onConflictDoNothing으로 throw 없이 통과.
         // 진짜 저장 실패(FK 위반 등)는 throw되어 브로드캐스트도 함께 중단 —
         // DB에 없는 획이 타인 화면에 남는 것 방지


### PR DESCRIPTION
> **스택 PR** — base가 `develop`이 아니라 #30의 브랜치다. `client/src/lib/date.ts`를 생성한 커밋이 #30에 있어서 `develop`에서 분기하면 충돌한다. #30이 머지되면 GitHub이 base를 `develop`으로 자동 재지정한다.

## 배경

날짜를 다루는 방식이 **두 갈래로 갈라져** 있었다.

- `client/src/lib/date.ts`의 `formatKoreanDate` — `new Date("2026-07-02")`가 ES 스펙상 UTC 자정으로 파싱돼 UTC 음수 오프셋 환경에서 하루 밀리는 걸 피하려고 **Date 객체를 일부러 안 썼다**. 정규식으로 문자열을 분해해 조립.
- `client/src/pages/WorshipList.tsx`의 `formatLastEdited` — 반대로 `new Date(...).toLocaleDateString("ko-KR")`. 위 함정에 그대로 노출된 잔존 코드.

date-fns의 `parse`/`parseISO`는 날짜 문자열을 **로컬 자정**으로 파싱해서 저 문제를 정석대로 해결한다. 라이브러리 하나로 방식을 통일하면서 갈라진 두 갈래를 합쳤다.

## 변경 내용

**클라이언트**
- `lib/date.ts` — `formatKoreanDate`를 date-fns `parse` + `format`으로 재작성, `formatKoreanDateShort` 추가
- `WorshipList.tsx` — 로컬 `formatLastEdited`를 지우고 위 모듈로 흡수. 클라이언트 날짜 로직이 `lib/date.ts` 하나로 모였다
- `parseISO`가 아니라 **`parse(_, "yyyy-MM-dd", _)`를 쓴다** — `parseISO`는 `"2026-07"`이나 `"2026-07-02T10:00:00Z"`도 통과시켜 형식 강제가 안 된다

**서버**
- `server/lib/date.ts`에 `nowIso()` 추가, `new Date().toISOString()` 6곳 교체 (`worships.ts` ×2, `sheets.ts`, `drawingHandler.ts`, `seed.ts`, `migrateDrawingCoords.ts`)
- date-fns `formatISO()`는 로컬 오프셋(`+09:00`) 형식에 밀리초도 없어 쓸 수 없다. `TZDate`로 UTC를 고정하고 포맷을 명시해 `.toISOString()`과 바이트 단위로 동일한 문자열을 만든다

**의존성** — `date-fns@^4` + `@date-fns/tz@^1` (client, server). `@base-ui/react`가 이미 optional peerDependency로 선언하던 버전과 정확히 맞는다.

## 출력 문자열은 바이트 단위로 동일하다

이게 이 PR의 핵심 리스크다. 두 군데가 문자열 동등성에 의존한다.

1. `formatKoreanDate`의 출력은 `WorshipEdit.tsx`가 **"자동 생성된 제목인지"를 문자열 비교로 판별**하는 데 쓰인다 (#30). 한 글자만 달라져도 이미 저장된 제목이 자동 제목으로 인식되지 않는다.
2. `created_at`/`updated_at`은 `orderBy(desc(...))` **사전순 정렬**에 쓰인다. 형식이 바뀌면 기존 행과 섞여 정렬이 조용히 틀어진다.

그래서 코드를 고치기 **전에** 신·구 구현을 대조해 증명했다.

| 대상 | 케이스 | 결과 |
|---|---|---|
| `formatKoreanDate` | 2020-01-01 ~ 2030-12-31 전 날짜 **4,018개** | 전부 일치 |
| `formatKoreanDateShort` | vs `toLocaleDateString("ko-KR")` **528개** | 전부 일치 |
| `nowIso()` | vs `.toISOString()` 무작위 타임스탬프 **5,006개** | 전부 일치 |

**KST / UTC / UTC−7(LA) / UTC+14(Kiritimati)** 네 타임존에서 모두 재실행해 동일하게 통과했다. `formatKoreanDate`는 타임존에 무관하게 같은 결과를 내므로 기존의 UTC 밀림 회피 의도가 그대로 유지된다.

### 의도된 동작 변화

기존 정규식이 통과시키던 **불가능한 날짜를 이제 걸러낸다**.

| 입력 | 기존 | 변경 후 |
|---|---|---|
| `2026-13-45` | `"2026년 13월 45일"` | `""` |
| `2026-02-30` | `"2026년 2월 30일"` | `""` |
| `2023-02-29` | `"2023년 2월 29일"` | `""` |
| `2026-00-10` | `"2026년 0월 10일"` | `""` |

반대로 제로패딩 강제가 약간 느슨해져 `"2026-7-2"`도 받는다. 생산자가 `<input type="date">`(항상 제로패딩) 하나뿐이라 실질 영향이 없다.

## 건드리지 않은 것

- **`worships.date`의 `YYYY-MM-DD` 계약** — 연·월 `LIKE` 필터, `/years`의 `substr(date,1,4)`, 사전순 정렬이 여기 의존한다. 날짜는 **표시할 때만** 파싱하고 저장·전송값은 원본 문자열을 그대로 흘려보낸다. `parseISO` → `Date` → `toISOString().slice(0,10)` 왕복은 하지 않는다 (KST에서 하루 밀린다)
- **`Date.now()` 5곳** — `canvas.ts`(ID 폴백), `useSheetZoomPan.ts`(더블탭 300ms), `useWorshipPresence.tsx`(토스트 키 ×2), `SheetCanvas.tsx`(60fps 스로틀). 전부 경과시간·유니크 키라 날짜가 아니다
- **`길튼 시스템/` 목업** — CLAUDE.md 수정 금지

## 검증

- `npm run check` 통과, warning 0
- 서버 테스트 **31개 통과** (기존 26 + `__tests__/date.test.ts` 5개 신규). KST/UTC/UTC−7/UTC+14 전부 통과
- API로 계약 확인 — `/years` → `[2024]`, 연 필터 3건, 연+월 필터 3건, 날짜 내림차순 정렬 유지
- DB 확인 — `created_at`/`updated_at`이 `2026-07-25T04:39:54.574Z` 24자 형식으로 저장됨
- Playwright로 **아이패드 세로 834×1194** / **아이폰 390×844** 양쪽에서 24건 통과
  - 목록: 날짜 `2024년 1월 7일`, 마지막 수정 `2026. 7. 25.`, 연도 필터 드롭다운·필터링 동작
  - 생성: 날짜/유형 선택 시 제목 자동 채움, 직접 쓴 제목 유지 (#30 회귀 없음)
  - **편집: 구 구현이 만든 형식의 자동 제목이 그대로 인식돼 날짜를 따라감** — 포맷 동등성의 실전 확인

## 관련

- #31 — 서버에 날짜 형식 검증이 없는 문제. 이 PR은 동작을 바꾸지 않는 순수 리팩터로 유지하려고 분리했다
- #30 — 이 PR의 base
