### PR TITLE
feat: 그리기 모드 팜 리젝션 — 펜으로만 그리기

### DIFF
--- a/client/src/components/SheetCanvas.tsx
+++ b/client/src/components/SheetCanvas.tsx
@@ -384,7 +384,8 @@ function SheetCanvas({
     // 펜 전용: 손가락/손바닥은 그리기에 관여하지 않는다.
     // activePointersRef에 넣지 않는 것이 핵심 — 넣으면 팜을 얹은 채 펜으로 그릴 때
     // 아래 2포인터 핸드오프가 발동해 획이 끊긴다.
-    // stopPropagation 이전에 반환하므로 터치는 지금처럼 부모로 흘러가 핀치줌이 그대로 동작한다.
+    // 핀치줌은 이 반환에 영향받지 않는다 — useSheetZoomPan은 TouchEvent(e.touches)로 동작하고,
+    // 캔버스의 native touchstart 리스너가 2점 이상일 때는 stopPropagation을 걸지 않아 부모까지 간다.
     if (penOnlyNow && e.pointerType === "touch") return;
 
     // 펜이 닿으면 손가락/팜이 점유하던 상태를 회수한다(펜 우선).
@@ -392,7 +393,8 @@ function SheetCanvas({
     // 2) 카운터를 비워 팜이 남긴 pointerId 때문에 펜의 첫 획이 핸드오프로 삼켜지는 것을 막는다.
     //    팜이 캔버스 밖에서 눌려 획을 시작하지 못한 경우에도 id는 남아 있으므로 clear가 필요하다.
     //    남은 id의 pointerup은 없는 키를 delete하는 no-op이라 안전하다.
-    //    (이 Set이 향후 touch 외 포인터도 추적하게 되면 필터링 delete로 바꿔야 한다)
+    //    이 Set은 지금도 mouse·pen을 담고 있고 펜 전용이 꺼져 있으면 touch까지 담는다.
+    //    펜 우선 정책상 그것들도 함께 비우는 게 의도다(펜이 닿는 순간 이전 점유는 무효).
     if (penOnlyNow && e.pointerType === "pen") {
       cancelDrawing();
       activePointersRef.current.clear();

--- a/client/src/components/SheetCanvas.tsx
+++ b/client/src/components/SheetCanvas.tsx
@@ -38,6 +38,13 @@ interface SheetCanvasProps {
   eraserWidth: number;
   paths: DrawingPath[];
   remoteInProgress: RemoteInProgressPath[];
+  // 펜으로만 그리기(팜 리젝션) — touch 포인터로는 획을 시작하지 않는다. pen/mouse는 계속 그린다.
+  penOnly: boolean;
+  // 스타일러스 최초 감지 알림. 반환값 = "이 호출로 펜 전용이 켜졌는가".
+  // 자동 감지가 켜지는 프레임에는 penOnly prop이 아직 이전 값이라 반환값으로 판단해야
+  // "팜이 먼저 닿고 곧바로 펜이 닿는" 첫 획부터 팜 리젝션이 적용된다.
+  onPenDetected?: () => boolean;
+  onDrawCancel?: (data: { pathId: string }) => void;
   onDrawStart?: (data: {
     pathId: string;
     color: string;
@@ -65,6 +72,9 @@ function SheetCanvas({
   eraserWidth,
   paths,
   remoteInProgress,
+  penOnly,
+  onPenDetected,
+  onDrawCancel,
   onDrawStart,
   onDrawMove,
   onPathAdd,
@@ -82,6 +92,10 @@ function SheetCanvas({
 
   const lastMoveTimeRef = useRef(0);
   const redrawCanvasRef = useRef<() => void>(() => {});
+  // 이 마운트에서 스타일러스를 이미 봤는지 — onPenDetected 중복 호출 방지
+  const penSeenRef = useRef(false);
+  // effect에서 cancelDrawing을 호출하기 위한 미러 (직접 호출하면 exhaustive-deps 경고)
+  const cancelDrawingRef = useRef<() => void>(() => {});
   const rafIdRef = useRef(0);
   const erasedPathIdsRef = useRef<Set<string>>(new Set());
   const activePointersRef = useRef<Set<number>>(new Set());
@@ -99,6 +113,9 @@ function SheetCanvas({
   // 1) 진행 중인 그리기 상태를 취소 — 펜을 누른 채 페이지가 바뀌어도 이전 획이 새 시트에 저장되지 않도록
   // 2) 이전 시트의 캔버스 픽셀을 페인트 전에 동기적으로 제거 — 잔상 방지(useLayoutEffect)
   useLayoutEffect(() => {
+    // 진행 중이던 획을 피어에게도 취소 통보한 뒤 리셋 — 아래 수동 리셋과 겹치지만
+    // cancelDrawing이 취소 emit·배치 종료를 한 경로로 처리하므로 재사용한다.
+    cancelDrawingRef.current();
     isDrawingRef.current = false;
     drawingPointerIdRef.current = null;
     currentPathRef.current = [];
@@ -337,20 +354,54 @@ function SheetCanvas({
     if (eraserType === "stroke") {
       onBatchEnd?.();
       erasedPathIdsRef.current = new Set();
+    } else if (currentPathIdRef.current) {
+      // 이미 drawing:start/move를 보낸 획 — 취소를 알리지 않으면 피어의 remoteInProgress에
+      // 영원히 남아 지워지지 않는 잔상이 된다. (영역 지우개도 drawing:start를 보내므로 포함)
+      onDrawCancel?.({ pathId: currentPathIdRef.current });
     }
 
     isDrawingRef.current = false;
     drawingPointerIdRef.current = null;
     currentPathRef.current = [];
+    // 같은 id로 두 번 취소되지 않도록 비운다 — 이후 읽는 곳은 전부 isDrawingRef 가드 뒤에 있다.
+    currentPathIdRef.current = "";
     requestRedraw();
   };
+  cancelDrawingRef.current = cancelDrawing;
 
   const handlePointerDown = (e: React.PointerEvent) => {
     if (!isDrawMode) return;
 
+    // 스타일러스 최초 감지 → 부모가 펜 전용 모드를 자동으로 켠다(기기당 1회).
+    // 켜진 프레임에는 penOnly prop이 아직 이전 값이므로 반환값으로 판단해야
+    // 그 즉시 아래 팜 리젝션이 적용된다.
+    let penOnlyNow = penOnly;
+    if (e.pointerType === "pen" && !penSeenRef.current) {
+      penSeenRef.current = true;
+      if (onPenDetected?.()) penOnlyNow = true;
+    }
+
+    // 펜 전용: 손가락/손바닥은 그리기에 관여하지 않는다.
+    // activePointersRef에 넣지 않는 것이 핵심 — 넣으면 팜을 얹은 채 펜으로 그릴 때
+    // 아래 2포인터 핸드오프가 발동해 획이 끊긴다.
+    // stopPropagation 이전에 반환하므로 터치는 지금처럼 부모로 흘러가 핀치줌이 그대로 동작한다.
+    if (penOnlyNow && e.pointerType === "touch") return;
+
+    // 펜이 닿으면 손가락/팜이 점유하던 상태를 회수한다(펜 우선).
+    // 1) 진행 중이던 손가락 획을 취소 — 피어에게도 drawing:cancel이 나간다.
+    // 2) 카운터를 비워 팜이 남긴 pointerId 때문에 펜의 첫 획이 핸드오프로 삼켜지는 것을 막는다.
+    //    팜이 캔버스 밖에서 눌려 획을 시작하지 못한 경우에도 id는 남아 있으므로 clear가 필요하다.
+    //    남은 id의 pointerup은 없는 키를 delete하는 no-op이라 안전하다.
+    //    (이 Set이 향후 touch 외 포인터도 추적하게 되면 필터링 delete로 바꿔야 한다)
+    if (penOnlyNow && e.pointerType === "pen") {
+      cancelDrawing();
+      activePointersRef.current.clear();
+    }
+
     activePointersRef.current.add(e.pointerId);
 
     // 2+ 포인터 → 그리기 취소, 부모 핀치줌으로 위임
+    // (펜 전용에서는 터치가 카운트되지 않아 팜을 얹어도 발동하지 않는다)
     if (activePointersRef.current.size >= 2) {
       cancelDrawing();
       return;

--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -350,7 +350,9 @@ function DrawingToolbar({
                       </div>
 
                       {/* 펜으로만 그리기(팜 리젝션) — 기기 설정에 저장되어 다음에도 유지된다.
-                          펜슬 없는 기기에서 켜면 그리기가 불가능해지므로 이 토글은 항상 노출해야 한다(탈출구). */}
+                          펜슬 없는 기기에서 켜면 그리기가 불가능해지므로 이 토글은 항상 노출한다.
+                          다만 여기는 그리기 모드에 들어가야 닿으므로, 자동 활성화 안내가 가리키는
+                          주 해제 경로는 기기 설정 페이지다(DeviceSettings.tsx). */}
                       <div>
                         <div className="text-xs font-medium text-muted-foreground mb-2">입력</div>
                         <Button

--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -11,6 +11,7 @@ import {
   Trash,
   Megaphone,
   Palette,
+  PenTool,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -27,6 +28,7 @@ export interface DrawingToolState {
   eraserType: EraserType;
   eraserWidth: number;
   toolPopoverOpen: boolean;
+  penOnly: boolean;
 }
 
 export interface DrawingToolActions {
@@ -39,6 +41,7 @@ export interface DrawingToolActions {
   setEraserType: Dispatch<SetStateAction<EraserType>>;
   setEraserWidth: Dispatch<SetStateAction<number>>;
   setToolPopoverOpen: (v: boolean) => void;
+  setPenOnly: (v: boolean) => void;
   undo: () => void;
   redo: () => void;
   setIsCompact: (v: boolean) => void;
@@ -85,6 +88,7 @@ function DrawingToolbar({
     eraserType,
     eraserWidth,
     toolPopoverOpen,
+    penOnly,
   } = tool;
   const {
     setIsDrawMode,
@@ -96,6 +100,7 @@ function DrawingToolbar({
     setEraserType,
     setEraserWidth,
     setToolPopoverOpen,
+    setPenOnly,
     undo,
     redo,
     setIsCompact,
@@ -342,6 +347,24 @@ function DrawingToolbar({
                             다시실행
                           </Button>
                         </div>
+                      </div>
+
+                      {/* 펜으로만 그리기(팜 리젝션) — 기기 설정에 저장되어 다음에도 유지된다.
+                          펜슬 없는 기기에서 켜면 그리기가 불가능해지므로 이 토글은 항상 노출해야 한다(탈출구). */}
+                      <div>
+                        <div className="text-xs font-medium text-muted-foreground mb-2">입력</div>
+                        <Button
+                          variant={penOnly ? "secondary" : "ghost"}
+                          className="h-11 w-full justify-between"
+                          aria-pressed={penOnly}
+                          onClick={() => setPenOnly(!penOnly)}
+                        >
+                          <span className="flex items-center gap-2">
+                            <PenTool />
+                            펜으로만 그리기
+                          </span>
+                          <span className="text-xs text-muted-foreground">{penOnly ? "켜짐" : "꺼짐"}</span>
+                        </Button>
                       </div>
                     </div>
                   </PopoverContent>

--- a/client/src/hooks/useDrawingSync.ts
+++ b/client/src/hooks/useDrawingSync.ts
@@ -309,6 +309,19 @@ export function useDrawingSync({ sheetId, profileId, enabled }: UseDrawingSyncOp
     [sheetId, socket],
   );
 
+  // 진행 중 획 취소 전송 — 로컬에서 버린 획을 피어의 remoteInProgress에서도 치운다.
+  // sheetId prop이 아니라 currentSheetIdRef(소켓이 실제로 join한 방)를 쓴다: 시트 전환 도중
+  // 취소가 나갈 때 prop은 이미 새 시트지만 room 입장/퇴장 effect는 아직 실행 전이라,
+  // 취소를 받아야 할 피어는 여전히 "이전 시트" 방에 있다. 의도된 divergence이므로 되돌리지 말 것.
+  const emitDrawCancel = useCallback(
+    (data: { pathId: string }) => {
+      const sheetRoomId = currentSheetIdRef.current;
+      if (!sheetRoomId) return;
+      socket.emit("drawing:cancel", { sheetId: sheetRoomId, pathId: data.pathId });
+    },
+    [socket],
+  );
+
   // 획 추가 (옵티미스틱 + 서버 동기화)
   const addPath = useCallback(
     (path: DrawingPath) => {
@@ -470,6 +483,7 @@ export function useDrawingSync({ sheetId, profileId, enabled }: UseDrawingSyncOp
     remoteInProgress: visibleRemoteInProgress,
     emitDrawStart,
     emitDrawMove,
+    emitDrawCancel,
     addPath,
     deletePath,
     clearMyPaths,

--- a/client/src/pages/DeviceSettings.tsx
+++ b/client/src/pages/DeviceSettings.tsx
@@ -1,9 +1,9 @@
 import { Link } from "react-router";
-import { ArrowLeft, PanelLeft, PanelRight, type LucideIcon } from "lucide-react";
+import { ArrowLeft, PanelLeft, PanelRight, PenTool, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { useDeviceSettingsStore, type PanelSide } from "@/store/deviceSettingsStore";
+import { useDeviceSettingsStore, selectPenOnlyActive, type PanelSide } from "@/store/deviceSettingsStore";
 
 // 패널 위치 선택지 — 화면상 배치와 카드 순서를 일치시킨다 (왼쪽 옵션이 왼쪽 칸)
 const panelSideOptions: { side: PanelSide; icon: LucideIcon; title: string; description: string }[] = [
@@ -15,6 +15,8 @@ const panelSideOptions: { side: PanelSide; icon: LucideIcon; title: string; desc
 export default function DeviceSettings() {
   const commandPanelSide = useDeviceSettingsStore((s) => s.commandPanelSide);
   const setCommandPanelSide = useDeviceSettingsStore((s) => s.setCommandPanelSide);
+  const penOnly = useDeviceSettingsStore(selectPenOnlyActive);
+  const setPenOnly = useDeviceSettingsStore((s) => s.setPenOnly);
 
   return (
     <div className="min-h-screen bg-background p-4 sm:p-8">
@@ -59,6 +61,31 @@ export default function DeviceSettings() {
                 );
               })}
             </div>
+          </CardContent>
+        </Card>
+
+        {/* 펜으로만 그리기 — 그리기 모드에 들어가지 않고도 끌 수 있는 경로.
+            펜슬이 처음 감지되면 자동으로 켜지고 기기에 계속 남으므로, 펜슬 없는 기기를
+            물려받은 사용자가 "그려지지 않는" 원인을 여기서 찾아 되돌릴 수 있어야 한다. */}
+        <Card className="rounded-2xl mt-6">
+          <CardContent className="p-8">
+            <h2 className="text-xl font-bold text-foreground mb-1">펜으로만 그리기</h2>
+            <p className="text-muted-foreground mb-6">
+              켜면 악보에 필기할 때 손바닥·손가락 터치를 무시하고 펜슬로만 그립니다. 펜슬이 처음 감지되면 자동으로
+              켜집니다. 펜슬이 없는 기기에서 켜면 그리기가 되지 않습니다.
+            </p>
+            <Button
+              variant={penOnly ? "secondary" : "outline"}
+              className="h-11 w-full justify-between"
+              aria-pressed={penOnly}
+              onClick={() => setPenOnly(!penOnly)}
+            >
+              <span className="flex items-center gap-2">
+                <PenTool />
+                펜으로만 그리기
+              </span>
+              <span className="text-xs text-muted-foreground">{penOnly ? "켜짐" : "꺼짐"}</span>
+            </Button>
           </CardContent>
         </Card>
       </div>

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -5,7 +5,7 @@ import { motion, useReducedMotion } from "motion/react";
 import { toast } from "sonner";
 import { useWorship, useCommands, useSheetDrawings, useAdjacentDrawingsPreload } from "@/hooks/queries";
 import { useAppStore } from "@/store/appStore";
-import { useDeviceSettingsStore, type PanelSide } from "@/store/deviceSettingsStore";
+import { useDeviceSettingsStore, selectPenOnlyActive, type PanelSide } from "@/store/deviceSettingsStore";
 import { useWorshipSocket } from "@/hooks/useWorshipSocket";
 import { useWorshipRoom } from "@/hooks/useWorshipRoom";
 import { useWorshipPresence } from "@/hooks/useWorshipPresence";
@@ -123,6 +123,7 @@ export default function Worship() {
     remoteInProgress,
     emitDrawStart,
     emitDrawMove,
+    emitDrawCancel,
     addPath,
     deletePath,
     startBatch,
@@ -232,6 +233,10 @@ export default function Worship() {
   // 기기 설정: 명령 패널 좌/우 위치 — 악보 목록은 항상 반대편
   const commandPanelSide = useDeviceSettingsStore((s) => s.commandPanelSide);
   const sidebarSide: PanelSide = commandPanelSide === "left" ? "right" : "left";
+  // 기기 설정: 펜으로만 그리기(팜 리젝션) — 스타일러스가 처음 감지되면 자동으로 켜진다
+  const penOnly = useDeviceSettingsStore(selectPenOnlyActive);
+  const setPenOnly = useDeviceSettingsStore((s) => s.setPenOnly);
+  const notePenDetected = useDeviceSettingsStore((s) => s.notePenDetected);
 
   const {
     x: pageX,
@@ -281,6 +286,18 @@ export default function Worship() {
     toast.success("현재 페이지를 호출했습니다");
   }, [id, currentProfileId, currentSheet, socket]);
 
+  // 스타일러스 최초 감지 → 펜으로만 그리기 자동 활성화. 안내는 실제로 켜진 그 1회만
+  // (1회 보장은 영속되는 penDetected에서 나오므로 별도 플래그가 필요 없다).
+  // 반환값은 SheetCanvas가 "지금 이 프레임부터 팜 리젝션 적용"을 판단하는 데 쓴다.
+  const handlePenDetected = useCallback(() => {
+    if (!notePenDetected()) return false;
+    toast.info("펜이 감지되어 펜으로만 그리기를 켰습니다", {
+      description: "손바닥이 닿아도 그려지지 않습니다. 도구 > 입력에서 끌 수 있습니다",
+      duration: 6000,
+    });
+    return true;
+  }, [notePenDetected]);
+
   // 모바일에선 한 쪽 드로어만 — 하나를 열면 다른 하나를 닫는다.
   const handleToggleSidebar = useCallback(() => {
     setShowSidebar((s) => {
@@ -312,6 +329,7 @@ export default function Worship() {
       eraserType,
       eraserWidth,
       toolPopoverOpen,
+      penOnly,
     }),
     [
       isDrawMode,
@@ -323,6 +341,7 @@ export default function Worship() {
       eraserType,
       eraserWidth,
       toolPopoverOpen,
+      penOnly,
     ],
   );
 
@@ -337,11 +356,12 @@ export default function Worship() {
       setEraserType,
       setEraserWidth,
       setToolPopoverOpen,
+      setPenOnly,
       undo: drawingUndo,
       redo: drawingRedo,
       setIsCompact,
     }),
-    [drawingUndo, drawingRedo],
+    [drawingUndo, drawingRedo, setPenOnly],
   );
 
   // 좌/우 패널 — 기기 설정(commandPanelSide)에 따라 실제 JSX 순서를 바꿔 렌더한다.
@@ -479,6 +499,9 @@ export default function Worship() {
                     eraserWidth={eraserWidth}
                     paths={drawingPaths}
                     remoteInProgress={remoteInProgress}
+                    penOnly={penOnly}
+                    onPenDetected={handlePenDetected}
+                    onDrawCancel={emitDrawCancel}
                     onDrawStart={emitDrawStart}
                     onDrawMove={emitDrawMove}
                     onPathAdd={addPath}
@@ -518,6 +541,7 @@ export default function Worship() {
                     eraserWidth={eraserWidth}
                     paths={previewDrawings ?? EMPTY_PATHS}
                     remoteInProgress={EMPTY_REMOTE}
+                    penOnly={false}
                     profileId={currentProfileId || ""}
                   />
                 </div>

--- a/client/src/pages/Worship.tsx
+++ b/client/src/pages/Worship.tsx
@@ -292,7 +292,9 @@ export default function Worship() {
   const handlePenDetected = useCallback(() => {
     if (!notePenDetected()) return false;
     toast.info("펜이 감지되어 펜으로만 그리기를 켰습니다", {
-      description: "손바닥이 닿아도 그려지지 않습니다. 도구 > 입력에서 끌 수 있습니다",
+      // 안내 경로는 기기 설정으로 잡는다 — 그리기 도구 팝오버는 그리기 모드에 들어가야
+      // 열 수 있고 툴바 구성도 바뀔 수 있는 반면, 기기 설정은 홈에서 바로 닿는다
+      description: "손바닥이 닿아도 그려지지 않습니다. 홈 > 기기 설정에서 끌 수 있습니다",
       duration: 6000,
     });
     return true;

--- a/client/src/store/deviceSettingsStore.ts
+++ b/client/src/store/deviceSettingsStore.ts
@@ -3,29 +3,64 @@ import { persist } from "zustand/middleware";
 
 export type PanelSide = "left" | "right";
 
+// 펜으로만 그리기(팜 리젝션) 모드.
+// "auto" = 사용자가 아직 정하지 않음 → 스타일러스가 감지되면 켜진다.
+// 사용자가 한 번이라도 토글하면 "on"/"off"로 고정되어 자동 감지가 그 선택을 덮지 않는다.
+// (불리언 하나로는 "펜을 써본 적 없는 사용자가 미리 꺼둔 경우"를 표현할 수 없어 3-state로 둔다)
+export type PenOnlyMode = "auto" | "on" | "off";
+
 // 기기별(로컬) 설정 — 서버에 저장되지 않고 이 기기의 localStorage에만 남는다.
 // 악보 목록 위치는 항상 명령 패널의 반대편으로 파생되므로 별도 필드를 두지 않는다.
-interface DeviceSettingsState {
+export interface DeviceSettingsState {
   commandPanelSide: PanelSide;
+  penOnlyMode: PenOnlyMode;
+  penDetected: boolean;
   setCommandPanelSide: (side: PanelSide) => void;
+  setPenOnly: (on: boolean) => void;
+  // 스타일러스 최초 감지 기록. 반환값 = "이번 호출로 펜 전용이 켜졌는가"(1회 안내 토스트용).
+  notePenDetected: () => boolean;
 }
+
+// 펜으로만 그리기가 실제로 적용 중인지 — 사용자 선택(on/off)이 우선, 미선택이면 감지 여부를 따른다.
+export const selectPenOnlyActive = (s: DeviceSettingsState) =>
+  s.penOnlyMode === "on" || (s.penOnlyMode === "auto" && s.penDetected);
 
 export const useDeviceSettingsStore = create<DeviceSettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       commandPanelSide: "right",
+      penOnlyMode: "auto",
+      penDetected: false,
       setCommandPanelSide: (side) => set({ commandPanelSide: side }),
+      setPenOnly: (on) => set({ penOnlyMode: on ? "on" : "off" }),
+      notePenDetected: () => {
+        if (get().penDetected) return false;
+        // "auto"였다면 이 기록으로 펜 전용이 켜진다 — 그 사실을 호출자에게 알려 토스트를 1회만 띄운다.
+        const turnedOn = get().penOnlyMode === "auto";
+        set({ penDetected: true });
+        return turnedOn;
+      },
     }),
     {
       name: "gilteun-device-settings",
-      partialize: (state) => ({ commandPanelSide: state.commandPanelSide }),
-      // localStorage가 손상돼 "left"/"right" 외 값이 복원되면 토글 버튼 렌더 조건이
-      // 양쪽 다 불일치해 버튼이 사라진다 — 검증해서 초기 상태(current)의 기본값으로 되돌린다.
+      partialize: (state) => ({
+        commandPanelSide: state.commandPanelSide,
+        penOnlyMode: state.penOnlyMode,
+        penDetected: state.penDetected,
+      }),
+      // localStorage가 손상돼 정의되지 않은 값이 복원되면 UI가 조용히 깨진다 —
+      // commandPanelSide는 토글 버튼 렌더 조건이 양쪽 다 불일치해 버튼이 사라지고,
+      // penOnlyMode는 selectPenOnlyActive가 영구히 false가 되어 펜슬 사용자가
+      // 이유도 모른 채 팜 리젝션을 못 받는다. 검증해서 초기 상태(current)의 기본값으로 되돌린다.
       merge: (persisted, current) => {
-        const side = (persisted as Partial<DeviceSettingsState> | undefined)?.commandPanelSide;
+        const p = persisted as Partial<DeviceSettingsState> | undefined;
+        const side = p?.commandPanelSide;
+        const mode = p?.penOnlyMode;
         return {
           ...current,
           commandPanelSide: side === "left" || side === "right" ? side : current.commandPanelSide,
+          penOnlyMode: mode === "auto" || mode === "on" || mode === "off" ? mode : current.penOnlyMode,
+          penDetected: typeof p?.penDetected === "boolean" ? p.penDetected : current.penDetected,
         };
       },
     },

--- a/server/socket/drawingHandler.ts
+++ b/server/socket/drawingHandler.ts
@@ -47,6 +47,13 @@ export function setupDrawingHandler(io: Server, socket: Socket): void {
     socket.to(`sheet:${data.sheetId}`).emit("drawing:moved", data);
   });
 
+  // 진행 중 획 취소 → 피어의 진행 중 렌더만 정리 (DB 저장 전 단계라 지울 row가 없음)
+  // 이 이벤트가 없으면 drawing:end로 확정되지 않고 버려진 획이 피어의 remoteInProgress에 영원히 남는다.
+  // 수신측은 기존 drawing:cancelled 핸들러를 그대로 재사용한다.
+  socket.on("drawing:cancel", (data: { sheetId: string; pathId: string }) => {
+    socket.to(`sheet:${data.sheetId}`).emit("drawing:cancelled", { sheetId: data.sheetId, pathId: data.pathId });
+  });
+
   // 드로잉 완료 → DB 저장 + 브로드캐스트
   socket.on(
     "drawing:end",


### PR DESCRIPTION
## 배경

애플펜슬로 악보에 필기할 때 손바닥이 화면에 닿으면 그대로 획이 그려졌다. `SheetCanvas`가 PointerEvent를 쓰면서도 `e.pointerType`을 한 번도 보지 않아 손바닥·손가락·펜슬·마우스를 전부 동일하게 취급하고 있었다.

팜 리젝션 전용 라이브러리는 사실상 존재하지 않는다. Excalidraw·tldraw·BigBlueButton 모두 `pointerType`으로 직접 거르는 방식이고, 이 코드베이스도 이미 PointerEvent 기반이라 게이트를 넣을 자리가 준비돼 있었다.

## 변경 내용

### 펜으로만 그리기 (팜 리젝션)

- `deviceSettingsStore`에 `penOnlyMode`(`"auto"` | `"on"` | `"off"`)와 `penDetected` 추가. 스타일러스가 처음 감지되면 자동으로 켜지고, 사용자가 한 번이라도 토글하면 `"on"`/`"off"`로 고정되어 자동 감지가 그 선택을 덮지 않는다. 불리언 하나로는 "펜을 써본 적 없는 사용자가 미리 꺼둔 경우"를 표현할 수 없어 3-state로 뒀다.
- 그리기 도구 팝오버에 **입력 > 펜으로만 그리기** on/off 토글. 펜슬 없는 기기에서 켜면 그리기가 불가능해지므로 이 토글은 항상 노출한다(유일한 탈출구).
- 켜진 상태에서 `touch` 포인터는 획을 시작하지 않는다. `pen`·`mouse`는 계속 그린다.
- 자동 감지 시 안내 토스트 1회 (기기당 1회, 영속되는 `penDetected`로 보장).

### 함께 고친 기존 버그 2건

**1. 팜을 얹고 펜슬로 그리면 획이 끊겼다.** 포인터가 2개가 되면 핀치줌 위임을 위해 `cancelDrawing()`이 호출되는데, 손바닥이 두 번째 포인터로 잡혀 발동했다. 팜 리젝션 없이는 펜슬 사용 자체가 깨져 있던 셈이다. 펜 전용에서는 `touch`를 `activePointersRef`에 넣지 않아 발동하지 않으며, 펜이 닿으면 진행 중이던 손가락 획을 선점 취소하고 카운터를 비운다.

**2. 취소된 획이 다른 사람 화면에 영구히 남았다.** `cancelDrawing()`이 로컬 상태만 정리하고 peer에게 알리지 않아, 이미 `drawing:start`가 나간 획이 상대방의 `remoteInProgress`에서 사라지지 않았다. 클라이언트→서버 취소 이벤트가 아예 없었다(`drawing:cancelled`는 서버가 id 충돌 시에만 발행). `drawing:cancel`을 추가하고 기존 `drawing:cancelled` 브로드캐스트와 수신 핸들러를 그대로 재사용한다 — 수신측 코드 변경 없음.

## 범위에서 제외한 것

- **손가락으로 그릴 때의 팜 리젝션.** 접촉 면적(`radiusX`/`radiusY`)은 iOS 13+에서 나오지만 값이 반올림돼 있고 하드웨어에 따라 그냥 `1`이 온다. 실기 측정 없이는 임계값을 정할 수 없어 별도 작업으로 뺐다.
- **그리기 모드에서의 손가락 페이지 넘기기·팬.** 현재 차단 동작을 유지한다 — 필기 중 손이 스쳐 페이지가 넘어가는 걸 막는 기존 설계 의도를 건드리지 않기 위해서다. `useSheetZoomPan` / `useSheetPageMotion` / 네이티브 터치 리스너는 손대지 않았다. 2손가락 핀치줌은 그대로 동작하며, 버그 1 수정 덕에 이제 펜슬로 그리는 중에도 획이 끊기지 않는다.

`client/CLAUDE.md`의 좌표·DPR 불변식은 건드리지 않았다. 좌표 변환·굵기 정규화 코드는 그대로고 포인터 수용 여부 게이트만 추가했다.

## 검증

`npm run check` 통과 (client·server 타입체크 + ESLint, 경고 0). 서버 vitest 26개 통과.

클라이언트 테스트 인프라가 없어, 실행 중인 앱에 pointerType별 이벤트를 합성하고 DB에 저장된 획을 확인하는 방식으로 검증했다. 아이패드 세로 `834×1194` / 아이폰 `390×844` 두 크기에서 레이아웃도 확인했다.

| 검증 | 결과 |
| --- | --- |
| 펜 전용 OFF — 터치로 그려짐 (무회귀) | 통과 |
| 펜 전용 ON — 터치 거부 | 통과 |
| 펜 전용 ON — 마우스는 그려짐 (데스크톱 무회귀) | 통과 |
| 펜 전용 ON — 펜은 그려짐 | 통과 |
| 팜 얹은 채 펜슬 — 펜 획만 저장, 안 끊김 (버그 1) | 통과 |
| 자동 감지 — 팜 선점 취소되고 펜 획만 남음 | 통과 |
| OFF 고정 — 펜 접촉 후에도 선택 유지 | 통과 |
| 손상된 localStorage — 크래시 없이 기본값 폴백 | 통과 |
| 피어에 `drawing:started` → `drawing:cancelled` 동일 pathId 전파 (버그 2) | 통과 |
| 시트 전환 중 취소가 "이전 시트" 방으로 전파 | 통과 |
| 그리기 모드 손가락 스와이프 — 펜 전용 on/off 무관하게 페이지 안 넘어감 | 통과 |

### 실기 확인이 필요한 항목

브라우저는 `pointerType === "pen"`을 합성할 수 있지만 실제 애플펜슬의 동작(iPadOS Safari가 팜과 펜슬 포인터를 어떤 순서로 내보내는지)까지 재현하지는 못한다. 아이패드 실기에서 아래를 확인해주세요.

- 손바닥을 얹은 채 펜슬로 긴 획 그리기 — 손바닥이 닿고 떨어질 때 획이 끊기지 않는지
- 형광펜 / 영역 지우개 / 획 지우개에서도 동일한지 (특히 획 지우개에서 손바닥이 남의 획을 지우지 않는지)
- 펜슬 획 도중 2손가락 핀치줌 — 확대되면서 획이 이어지고 위치가 어긋나지 않는지
