### PR TITLE
docs: 커밋 신원과 PR 서명 규칙을 CLAUDE.md에 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,17 +3,21 @@
 ## Git
 
 - **커밋 작성자는 항상 `Jeongyun Lee <solst_ice@naver.com>`** — 저장소 기존 커밋과 같은 신원이어야 GitHub 귀속이 이어짐
-  - 원격/컨테이너 환경은 git 기본값이 `Claude <noreply@anthropic.com>`로 잡혀 있는 경우가 있음. **커밋 전에 `git config user.email`을 확인할 것**
+  - 원격/컨테이너 환경은 git 기본값이 `Claude <noreply@anthropic.com>`로 잡혀 있는 경우가 있음
   - `git config user.name "Jeongyun Lee" && git config user.email "solst_ice@naver.com"`
-  - 이미 잘못된 신원으로 푸시했다면 아래로 되돌린 뒤 `git push --force-with-lease` (`--force`는 남의 푸시를 덮어쓸 수 있음)
+  - **커밋 전 확인은 `git var GIT_AUTHOR_IDENT`로 할 것.** `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` 환경변수가 `user.name`/`user.email` config를 덮어쓰므로, `git config user.email`만 보면 값은 맞는데 실제 작성자는 `Claude`로 들어간다. 커밋 후 `git log -1 --format='%an <%ae>'`로 한 번 더 확인하면 확실하다
+  - 이미 잘못된 신원으로 푸시했다면 아래로 되돌린 뒤 force push 한다 (`--force`는 남의 푸시를 덮어쓸 수 있음)
     - **커밋 1개**: `git commit --amend --author="Jeongyun Lee <solst_ice@naver.com>"`
     - **여러 개**: `--amend`는 맨 위 커밋 하나만 고친다. 아래처럼 일괄 처리할 것 (`-i` 없이 동작하고, 지정한 커밋 **다음**부터 고쳐진다)
       - `git rebase <마지막_정상_커밋> --exec 'git commit --amend --no-edit --author="Jeongyun Lee <solst_ice@naver.com>"'`
-    - **스택 PR**이면 위 브랜치를 고친 뒤 아래 브랜치를 `git rebase --onto <새_헤드> <옛_헤드>`로 옮겨야 함
+      - 재작성 범위에 **머지 커밋이 있으면 이력이 평탄화된다.** 이 저장소는 feature 브랜치가 `develop`을 머지해 오는 패턴을 상시로 쓰므로, 실행 전 `git log --merges <마지막_정상_커밋>..HEAD`로 확인하고 머지가 걸리면 범위를 좁히거나 `--rebase-merges`를 함께 쓸 것
+    - **스택 PR**이면 **base 브랜치를 먼저 고친 뒤 그 위에 쌓인 후속 브랜치를 옮긴다** — `git switch <후속_브랜치> && git rebase --onto <base_새_헤드> <base_옛_헤드>` (예: #30이 base, 그 위의 #32가 후속). "위/아래"로 외우지 말 것 — 방향을 반대로 잡으면 base 브랜치가 후속 브랜치 헤드로 통째로 이동해 diff가 오염된다
+    - 되돌린 뒤 `git push --force-with-lease=<브랜치>:<재작성_전_원격_SHA> origin <로컬_ref>:<브랜치>` — **기대 SHA를 반드시 명시할 것.** 값 없는 `--force-with-lease`는 remote-tracking ref만 보고 판단하므로, 에디터나 다른 세션이 백그라운드에서 `git fetch`를 돌리면 보호가 무효화된다
     - `--reset-author`는 원래 작성 시각까지 지우므로 쓰지 말 것
 - 커밋 메시지에 `Co-Authored-By` 태그 절대 붙이지 않기
 - PR 본문/설명에 `🤖 Generated with Claude Code` 등 Claude Code 생성 표기·서명 붙이지 않기
   - PR 생성 API가 본문 끝에 서명을 자동으로 붙이는 경우가 있음 — 생성 후 본문을 확인하고 붙어 있으면 제거할 것
+  - **본문뿐 아니라 코멘트도 대상이다.** 일반 코멘트와 인라인 리뷰 코멘트는 API가 갈려 있어(`issues/<n>/comments`, `pulls/<n>/comments`) 한쪽만 훑으면 놓친다. 단, `claude[bot]`이 남긴 코멘트의 서명은 봇 자신의 것이므로 건드리지 않는다
 - `develop` 브랜치에서 개발 → `main`에 머지/push 시 Railway 자동 배포
 - 평소 작업은 `develop`에서 진행할 것
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,12 @@
 - **커밋 작성자는 항상 `Jeongyun Lee <solst_ice@naver.com>`** — 저장소 기존 커밋과 같은 신원이어야 GitHub 귀속이 이어짐
   - 원격/컨테이너 환경은 git 기본값이 `Claude <noreply@anthropic.com>`로 잡혀 있는 경우가 있음. **커밋 전에 `git config user.email`을 확인할 것**
   - `git config user.name "Jeongyun Lee" && git config user.email "solst_ice@naver.com"`
-  - 이미 잘못된 신원으로 푸시했다면 `git commit --amend --author="Jeongyun Lee <solst_ice@naver.com>"` 후 force push (`--reset-author`는 작성 시각까지 지우므로 쓰지 말 것)
+  - 이미 잘못된 신원으로 푸시했다면 아래로 되돌린 뒤 `git push --force-with-lease` (`--force`는 남의 푸시를 덮어쓸 수 있음)
+    - **커밋 1개**: `git commit --amend --author="Jeongyun Lee <solst_ice@naver.com>"`
+    - **여러 개**: `--amend`는 맨 위 커밋 하나만 고친다. 아래처럼 일괄 처리할 것 (`-i` 없이 동작하고, 지정한 커밋 **다음**부터 고쳐진다)
+      - `git rebase <마지막_정상_커밋> --exec 'git commit --amend --no-edit --author="Jeongyun Lee <solst_ice@naver.com>"'`
+    - **스택 PR**이면 위 브랜치를 고친 뒤 아래 브랜치를 `git rebase --onto <새_헤드> <옛_헤드>`로 옮겨야 함
+    - `--reset-author`는 원래 작성 시각까지 지우므로 쓰지 말 것
 - 커밋 메시지에 `Co-Authored-By` 태그 절대 붙이지 않기
 - PR 본문/설명에 `🤖 Generated with Claude Code` 등 Claude Code 생성 표기·서명 붙이지 않기
   - PR 생성 API가 본문 끝에 서명을 자동으로 붙이는 경우가 있음 — 생성 후 본문을 확인하고 붙어 있으면 제거할 것

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,13 @@
 
 ## Git
 
+- **커밋 작성자는 항상 `Jeongyun Lee <solst_ice@naver.com>`** — 저장소 기존 커밋과 같은 신원이어야 GitHub 귀속이 이어짐
+  - 원격/컨테이너 환경은 git 기본값이 `Claude <noreply@anthropic.com>`로 잡혀 있는 경우가 있음. **커밋 전에 `git config user.email`을 확인할 것**
+  - `git config user.name "Jeongyun Lee" && git config user.email "solst_ice@naver.com"`
+  - 이미 잘못된 신원으로 푸시했다면 `git commit --amend --author="Jeongyun Lee <solst_ice@naver.com>"` 후 force push (`--reset-author`는 작성 시각까지 지우므로 쓰지 말 것)
 - 커밋 메시지에 `Co-Authored-By` 태그 절대 붙이지 않기
 - PR 본문/설명에 `🤖 Generated with Claude Code` 등 Claude Code 생성 표기·서명 붙이지 않기
+  - PR 생성 API가 본문 끝에 서명을 자동으로 붙이는 경우가 있음 — 생성 후 본문을 확인하고 붙어 있으면 제거할 것
 - `develop` 브랜치에서 개발 → `main`에 머지/push 시 Railway 자동 배포
 - 평소 작업은 `develop`에서 진행할 것
 


### PR DESCRIPTION
## 배경

원격/컨테이너 환경은 git 기본값이 `Claude <noreply@anthropic.com>`로 잡혀 있어서, 별도로 설정하지 않으면 커밋 작성자가 그대로 들어간다. 실제로 이번 작업에서 커밋 2개(#30, #32)가 그렇게 들어가 되돌렸다.

컨테이너는 세션마다 새로 만들어져 `git config --local` 설정이 남지 않는다. 그래서 규칙을 문서에 박아둔다.

## 변경 내용

루트 `CLAUDE.md`의 Git 섹션에 두 항목을 추가·보강했다.

**커밋 신원 (신규)**
- 작성자를 `Jeongyun Lee <solst_ice@naver.com>`로 고정 — 저장소 기존 커밋 72개 전부가 쓰는 신원이라 GitHub 귀속이 이어진다
- 커밋 전에 `git config user.email`을 확인하라는 지시와 설정 명령
- 잘못 푸시했을 때의 복구 방법. `--reset-author`는 원래 작성 시각까지 덮어쓰므로 `--author=`를 쓰라고 명시했다

**PR 서명 (기존 항목에 덧붙임)**
- PR 생성 API가 본문 끝에 `Generated by Claude Code` 서명을 자동으로 붙이는 경우가 있다. 기존 "서명 붙이지 않기" 규칙만으로는 이 경우가 안 걸려서, 생성 후 본문을 확인하고 제거하라는 항목을 추가했다 (#30, #32 둘 다 실제로 붙어서 지웠다)

## 검증

문서만 바뀌어 코드 영향은 없다. `npx prettier --check CLAUDE.md` 통과.

이 PR의 커밋 자체가 새 규칙대로 `Jeongyun Lee <solst_ice@naver.com>`로 들어갔다.

## 관련

`develop`에서 분기했다. #30 / #32와 독립적이라 먼저 머지해도 된다.
