### PR TITLE
feat: 도구 미리보기를 팔레트 트리거로 전환 (도구 버튼 제거)

### DIFF
--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -1,17 +1,5 @@
 import { memo, type Dispatch, type SetStateAction } from "react";
-import {
-  Pencil,
-  Highlighter,
-  Eye,
-  Eraser,
-  Undo,
-  Redo,
-  Minus,
-  Plus as PlusIcon,
-  Trash,
-  Megaphone,
-  Palette,
-} from "lucide-react";
+import { Pencil, Highlighter, Eye, Eraser, Undo, Redo, Minus, Plus as PlusIcon, Trash, Megaphone } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import type { EraserType } from "@/components/SheetCanvas";
@@ -102,8 +90,21 @@ function DrawingToolbar({
   } = actions;
 
   // 그리기 도구가 펜/형광펜인지(지우개가 아닐 때만 색·굵기 활성 표시)
-  const isPenActive = !isHighlighter && eraserType === "none";
-  const isHighlighterActive = isHighlighter && eraserType === "none";
+  const isEraser = eraserType !== "none";
+  const isPenActive = !isHighlighter && !isEraser;
+  const isHighlighterActive = isHighlighter && !isEraser;
+
+  // 팔레트 트리거에 현재 도구·색·굵기를 그대로 표시 (팝오버를 안 열어도 상태를 알 수 있게)
+  const activeColor = isHighlighter ? highlighterColor : selectedColor;
+  const activeWidth = isEraser ? eraserWidth : isHighlighter ? highlighterWidth : penWidth;
+  const ActiveToolIcon = isEraser ? (eraserType === "stroke" ? Trash : Eraser) : isHighlighter ? Highlighter : Pencil;
+  const activeToolLabel = isEraser
+    ? eraserType === "stroke"
+      ? "획 지우개"
+      : "영역 지우개"
+    : isHighlighter
+      ? "형광펜"
+      : "펜";
 
   // 명령 패널 토글은 패널이 나타나는 가장자리와 같은 쪽에 배치 (기기 설정으로 좌/우 스왑)
   const commandPanelButton = (
@@ -157,9 +158,20 @@ function DrawingToolbar({
             {isDrawMode && (
               <>
                 <Popover open={toolPopoverOpen} onOpenChange={setToolPopoverOpen}>
-                  <PopoverTrigger render={<Button variant="secondary" className="h-11" />}>
-                    <Palette />
-                    도구
+                  <PopoverTrigger
+                    render={<Button variant="secondary" className="h-11" />}
+                    title="도구 설정"
+                    aria-label={`도구 설정 열기 (현재 ${activeToolLabel}, 굵기 ${activeWidth})`}
+                  >
+                    <ActiveToolIcon className="size-4" />
+                    <span className="text-sm">{activeToolLabel}</span>
+                    {!isEraser && (
+                      <span
+                        className="size-4 shrink-0 rounded-full border border-border"
+                        style={{ backgroundColor: activeColor }}
+                      />
+                    )}
+                    <span className="text-sm font-medium tabular-nums">{activeWidth}</span>
                   </PopoverTrigger>
                   <PopoverContent className="w-80 p-4" align="start">
                     <div className="space-y-4">
@@ -346,43 +358,6 @@ function DrawingToolbar({
                     </div>
                   </PopoverContent>
                 </Popover>
-
-                {/* 현재 도구·색·굵기 상시 표시 (팝오버를 안 열어도 상태를 알 수 있게) */}
-                {(() => {
-                  const isEraser = eraserType !== "none";
-                  const curColor = isHighlighter ? highlighterColor : selectedColor;
-                  const curWidth = isEraser ? eraserWidth : isHighlighter ? highlighterWidth : penWidth;
-                  const ToolIcon = isEraser
-                    ? eraserType === "stroke"
-                      ? Trash
-                      : Eraser
-                    : isHighlighter
-                      ? Highlighter
-                      : Pencil;
-                  const label = isEraser
-                    ? eraserType === "stroke"
-                      ? "획 지우개"
-                      : "영역 지우개"
-                    : isHighlighter
-                      ? "형광펜"
-                      : "펜";
-                  return (
-                    <div
-                      className="flex h-11 shrink-0 items-center gap-2 whitespace-nowrap rounded-md border bg-muted/40 px-3 text-muted-foreground"
-                      aria-label={`현재 도구: ${label}, 굵기 ${curWidth}`}
-                    >
-                      <ToolIcon className="size-4" />
-                      <span className="hidden text-sm sm:inline">{label}</span>
-                      {!isEraser && (
-                        <span
-                          className="size-4 shrink-0 rounded-full border border-border"
-                          style={{ backgroundColor: curColor }}
-                        />
-                      )}
-                      <span className="text-sm font-medium tabular-nums text-foreground">{curWidth}</span>
-                    </div>
-                  );
-                })()}
 
                 <Button
                   variant="secondary"

--- a/client/src/components/worship/DrawingToolbar.tsx
+++ b/client/src/components/worship/DrawingToolbar.tsx
@@ -95,8 +95,12 @@ function DrawingToolbar({
   const isHighlighterActive = isHighlighter && !isEraser;
 
   // 팔레트 트리거에 현재 도구·색·굵기를 그대로 표시 (팝오버를 안 열어도 상태를 알 수 있게)
+  // 획 지우개는 굵기 개념이 없어 null로 둔다 — 삭제 판정은 SheetCanvas가 고정 threshold(20)와
+  // 대상 획의 굵기로만 하고(findPathAtPoint), 팔레트의 "지우개 크기"도 영역 지우개 전용이라
+  // 사용자가 바꿀 수도 없는 숫자를 트리거에 띄우게 된다.
   const activeColor = isHighlighter ? highlighterColor : selectedColor;
-  const activeWidth = isEraser ? eraserWidth : isHighlighter ? highlighterWidth : penWidth;
+  const activeWidth =
+    eraserType === "stroke" ? null : isEraser ? eraserWidth : isHighlighter ? highlighterWidth : penWidth;
   const ActiveToolIcon = isEraser ? (eraserType === "stroke" ? Trash : Eraser) : isHighlighter ? Highlighter : Pencil;
   const activeToolLabel = isEraser
     ? eraserType === "stroke"
@@ -161,17 +165,17 @@ function DrawingToolbar({
                   <PopoverTrigger
                     render={<Button variant="secondary" className="h-11" />}
                     title="도구 설정"
-                    aria-label={`도구 설정 열기 (현재 ${activeToolLabel}, 굵기 ${activeWidth})`}
+                    aria-label={`도구 설정 (현재 ${activeToolLabel}${activeWidth === null ? "" : `, 굵기 ${activeWidth}`})`}
                   >
-                    <ActiveToolIcon className="size-4" />
-                    <span className="text-sm">{activeToolLabel}</span>
+                    <ActiveToolIcon />
+                    <span>{activeToolLabel}</span>
                     {!isEraser && (
                       <span
                         className="size-4 shrink-0 rounded-full border border-border"
                         style={{ backgroundColor: activeColor }}
                       />
                     )}
-                    <span className="text-sm font-medium tabular-nums">{activeWidth}</span>
+                    {activeWidth !== null && <span className="tabular-nums">{activeWidth}</span>}
                   </PopoverTrigger>
                   <PopoverContent className="w-80 p-4" align="start">
                     <div className="space-y-4">


### PR DESCRIPTION
## 배경

그리기 모드 도구 바에는 팔레트를 여는 `도구` 버튼과, 현재 도구·색·굵기를 보여주는 읽기 전용 미리보기 칩이 나란히 있었다. 미리보기 칩을 눌렀을 때 팔레트가 열리는 게 자연스러운데 아무 반응이 없었고, 칩이 이미 "현재 도구 상태"를 대표하고 있으니 `도구` 버튼은 중복이었다.

## 변경 내용

`client/src/components/worship/DrawingToolbar.tsx` 단일 파일 변경.

- 미리보기 칩(읽기 전용 `div`)을 `PopoverTrigger`로 전환 — 미리보기를 누르면 팔레트가 열린다
- 중복이 된 `도구` 버튼 제거 (`Palette` 아이콘 import도 함께 정리)
- 미리보기 파생값(아이콘·라벨·색·굵기)을 IIFE에서 컴포넌트 상단으로 승격 — 트리거가 `Popover` JSX 안쪽으로 들어가 기존 IIFE 스코프로는 접근할 수 없다
- 트리거는 `secondary` 버튼 + `h-11`로 다른 도구 바 버튼과 톤·터치 타깃(44px)을 통일하고, 기존 칩의 `bg-muted/40` 비활성 인상은 버렸다
- 도구 라벨을 상시 표시 (`hidden sm:inline` 해제) — 버튼 하나가 빠져 아이폰 폭에서도 여유가 생겼고, `도구` 텍스트가 사라진 만큼 라벨이 트리거의 정체를 대신 설명한다

`Worship.tsx`는 손대지 않았다. 팝오버 본문(도구·색상·굵기·지우개·실행취소), 지우개 선택 시 자동 닫힘, 팔레트 열림 중 드로잉·페이지 넘김 억제는 모두 그대로다.

## 검증

`npm run check` (client 타입체크·ESLint / server 타입체크·ESLint / prettier) 전부 통과.

실제 앱을 띄워 Chromium으로 **아이패드 세로 834×1194**와 **아이폰 390×844** 양쪽에서 구동 확인 (콘솔 에러 없음):

- `도구` 버튼 사라짐 (DOM 카운트 0), 미리보기 트리거 크기 101×44
- 미리보기 탭 → 팔레트 열림, 트리거 아래에 정렬
- 팔레트에서 형광펜 · 핑크 · 굵기 변경 → 트리거가 즉시 `형광펜 ● 20`으로 갱신 (색 점 `rgb(249, 168, 212)`)
- `획` 지우개 선택 → 팝오버 자동 닫힘, 트리거가 `획 지우개 15`로 바뀌고 색 점은 사라짐
- 악보를 업로드해 드로잉 경로까지 확인: 팔레트 닫힘 상태 드래그 → 획 0→1 저장, 팔레트 열린 상태 드래그 → 1→1 (기존 게이팅 유지)

아이폰 390px에서는 undo/redo가 둘째 줄로 감싸이는데, 변경 전에는 버튼이 하나 더 있어 동일하게 감싸였다 — 회귀가 아니라 한 칸 여유가 생긴 상태다.
